### PR TITLE
Add Event model with validation and tests

### DIFF
--- a/domain/models/event.py
+++ b/domain/models/event.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from datetime import date
+
+from pydantic import BaseModel, Field, field_validator, model_validator, ConfigDict
+
+
+class Event(BaseModel):
+    """Event entity linking countries and participants."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    eid: str = Field(..., min_length=1, description="Event identifier")
+    title: str = Field(..., min_length=1, description="Event title")
+    location: str = Field(..., min_length=1, description="Event location")
+    date_from: date = Field(..., alias="dateFrom", description="Start date")
+    date_to: date = Field(..., alias="dateTo", description="End date")
+    host_country: str = Field(..., min_length=1, description="Country CID hosting the event")
+    participant_ids: list[str] = Field(default_factory=list, description="List of participant PIDs")
+
+    # ----------------- Validators -----------------
+
+    @model_validator(mode="after")
+    def _validate_dates(self) -> "Event":
+        if self.date_from > self.date_to:
+            raise ValueError("date_from must be on or before date_to")
+        return self
+
+    @field_validator("host_country", mode="after")
+    @classmethod
+    def _validate_host_country(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("host_country must be a non-empty string")
+        return v
+
+    @field_validator("participant_ids", mode="after")
+    @classmethod
+    def _validate_participant_ids(cls, v: list[str]) -> list[str]:
+        if any((not pid) or (not str(pid).strip()) for pid in v):
+            raise ValueError("participant_ids must contain only non-empty strings")
+        return v
+
+    # ----------------- Mongo helpers -----------------
+
+    def to_mongo(self) -> dict:
+        """Serialize to MongoDB-compatible dict using aliases."""
+        return self.model_dump(by_alias=True, exclude_none=True)
+
+    @classmethod
+    def from_mongo(cls, doc: dict | None) -> "Event | None":
+        """Deserialize from MongoDB document."""
+        if not doc:
+            return None
+        return cls(**doc)
+

--- a/tests/test_event_model.py
+++ b/tests/test_event_model.py
@@ -1,0 +1,76 @@
+from datetime import date
+import os
+import sys
+
+import pytest
+
+# Ensure the project root is on sys.path for importing the domain package
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from domain.models.event import Event
+
+
+def test_event_to_from_mongo_roundtrip():
+    evt = Event(
+        eid="E001",
+        title="Summit",
+        location="Zagreb",
+        date_from=date(2025, 5, 1),
+        date_to=date(2025, 5, 3),
+        host_country="c001",
+        participant_ids=["p001", "p002"],
+    )
+
+    mongo_doc = evt.to_mongo()
+    assert mongo_doc == {
+        "eid": "E001",
+        "title": "Summit",
+        "location": "Zagreb",
+        "dateFrom": date(2025, 5, 1),
+        "dateTo": date(2025, 5, 3),
+        "host_country": "c001",
+        "participant_ids": ["p001", "p002"],
+    }
+
+    evt2 = Event.from_mongo(mongo_doc)
+    assert evt2 == evt
+
+    assert Event.from_mongo(None) is None
+
+
+def test_event_date_validation():
+    with pytest.raises(ValueError):
+        Event(
+            eid="E1",
+            title="Invalid",
+            location="X",
+            date_from=date(2025, 6, 1),
+            date_to=date(2025, 5, 1),
+            host_country="c001",
+        )
+
+
+def test_event_requires_host_country():
+    with pytest.raises(ValueError):
+        Event(
+            eid="E1",
+            title="No Country",
+            location="X",
+            date_from=date(2025, 5, 1),
+            date_to=date(2025, 5, 2),
+            host_country="",
+        )
+
+
+def test_event_participant_ids_non_empty():
+    with pytest.raises(ValueError):
+        Event(
+            eid="E1",
+            title="Bad participants",
+            location="X",
+            date_from=date(2025, 5, 1),
+            date_to=date(2025, 5, 2),
+            host_country="c001",
+            participant_ids=["p001", ""],
+        )
+


### PR DESCRIPTION
## Summary
- define `Event` domain model with date aliases, participant and country references, and MongoDB helpers
- enforce non-empty country and participant IDs and chronological dates
- add unit tests covering serialization and validation errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b93fb4b6448322b71194119e4c9752