### PR TITLE
Add training test model and repository

### DIFF
--- a/domain/models/training_test_model.py
+++ b/domain/models/training_test_model.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class AttemptType(StrEnum):
+    """Enumeration for test attempt type."""
+    pre = "pre"
+    post = "post"
+
+
+class TrainingTest(BaseModel):
+    """Participant test score for a specific training event."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    eid: str = Field(..., min_length=1, description="Event/training identifier")
+    pid: str = Field(..., min_length=1, description="Participant identifier")
+    type: AttemptType = Field(..., description="Attempt type: 'pre' or 'post'")
+    score: float = Field(..., ge=0, description="Score for this attempt")
+
+    def to_mongo(self) -> dict:
+        """Serialize to MongoDB-compatible dict."""
+        return self.model_dump(by_alias=True, exclude_none=True)
+
+    @classmethod
+    def from_mongo(cls, doc: dict | None) -> "TrainingTest | None":
+        """Deserialize from MongoDB document."""
+        if not doc:
+            return None
+        return cls(**doc)

--- a/repositories/training_test_repository.py
+++ b/repositories/training_test_repository.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pymongo import ASCENDING
+from pymongo.collection import Collection
+
+from config.database import mongodb
+from domain.models.training_test_model import TrainingTest, AttemptType
+
+
+class TrainingTestRepository:
+    """Repository for storing participant test scores."""
+
+    def __init__(self) -> None:
+        self.collection: Collection = mongodb.db()["tests"]
+
+    def ensure_indexes(self) -> None:
+        """Ensure unique index on (eid, pid, type)."""
+        self.collection.create_index(
+            [("eid", ASCENDING), ("pid", ASCENDING), ("type", ASCENDING)],
+            unique=True,
+        )
+
+    def save(self, test: TrainingTest) -> str:
+        """Insert or update a test score."""
+        result = self.collection.update_one(
+            {"eid": test.eid, "pid": test.pid, "type": test.type.value},
+            {"$set": test.to_mongo()},
+            upsert=True,
+        )
+        return str(result.upserted_id) if result.upserted_id else ""
+
+    def find(self, eid: str, pid: str, type: AttemptType) -> Optional[TrainingTest]:
+        """Find a specific test by composite key."""
+        doc = self.collection.find_one({"eid": eid, "pid": pid, "type": type.value})
+        return TrainingTest.from_mongo(doc) if doc else None
+
+    def find_by_event(self, eid: str) -> List[TrainingTest]:
+        """Find all tests for a given event."""
+        cursor = self.collection.find({"eid": eid})
+        return [TrainingTest.from_mongo(doc) for doc in cursor]

--- a/tests/test_training_test_model.py
+++ b/tests/test_training_test_model.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+import pytest
+
+# Ensure project root on sys.path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from domain.models.training_test_model import TrainingTest, AttemptType
+
+
+def test_training_test_to_from_mongo_roundtrip():
+    t = TrainingTest(eid="E1", pid="P1", type=AttemptType.pre, score=88.5)
+    doc = t.to_mongo()
+    assert doc == {"eid": "E1", "pid": "P1", "type": "pre", "score": 88.5}
+    assert TrainingTest.from_mongo(doc) == t
+    assert TrainingTest.from_mongo(None) is None
+
+
+def test_training_test_score_non_negative():
+    with pytest.raises(ValueError):
+        TrainingTest(eid="E1", pid="P1", type=AttemptType.post, score=-5)


### PR DESCRIPTION
## Summary
- add `TrainingTest` model to capture pre/post training scores
- enforce unique `(eid, pid, type)` combinations via `TrainingTestRepository`
- cover serialization and validation in new unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba9368b9888322a5fe9177ab19300a