### PR TITLE
Add MongoDB user login and authentication middleware

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,9 @@ from flask import Flask, jsonify
 from config.database import mongodb
 from repositories.country_repository import CountryRepository
 from repositories.participant_repository import ParticipantRepository
+from middleware.auth import auth_bp, login_required
+from routes.main import main_bp
+from routes.participants import participants_bp
 
 
 def create_app() -> Flask:
@@ -12,8 +15,13 @@ def create_app() -> Flask:
     - Initializes extensions.
     """
     app = Flask(__name__)
+    app.secret_key = os.getenv("SECRET_KEY", "dev")
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(main_bp)
+    app.register_blueprint(participants_bp)
 
     @app.route("/health", methods=["GET"])
+    @login_required
     def health_check():
         """
         Simple health-check route.
@@ -32,6 +40,7 @@ def create_app() -> Flask:
 
 
     @app.route("/stats", methods=["GET"])
+    @login_required
     def get_stats():
         """
         Get statistics about the database including counts of participants and countries.
@@ -59,6 +68,7 @@ def create_app() -> Flask:
             }), 500
 
     @app.route("/stats/detailed", methods=["GET"])
+    @login_required
     def get_detailed_stats():
         """
         Get more detailed statistics about the database.
@@ -119,3 +129,4 @@ if __name__ == "__main__":
         debug=getenv("FLASK_DEBUG", "0") == "1",
         use_reloader=False,  # <- important
     )
+

--- a/repositories/users_repository.py
+++ b/repositories/users_repository.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Optional
+from bson import ObjectId
+
+from config.database import mongodb
+from domain.models.user import User
+
+
+class UserRepository:
+    """CRUD operations for users collection."""
+
+    def __init__(self) -> None:
+        self.collection = mongodb.collection("users")
+        # ensure index for fast username lookups
+        self.collection.create_index("username", unique=True)
+
+    def create(self, user: User) -> str:
+        result = self.collection.insert_one(user.to_mongo())
+        return str(result.inserted_id)
+
+    def get_by_id(self, user_id: str) -> Optional[User]:
+        doc = self.collection.find_one({"_id": ObjectId(user_id)})
+        return User.from_mongo(doc)
+
+    def get_by_username(self, username: str) -> Optional[User]:
+        doc = self.collection.find_one({"username": username})
+        return User.from_mongo(doc)
+
+    def update(self, user_id: str, data: dict) -> int:
+        data = {k: v for k, v in data.items() if k != "_id"}
+        result = self.collection.update_one({"_id": ObjectId(user_id)}, {"$set": data})
+        return result.modified_count
+
+    def delete(self, user_id: str) -> int:
+        result = self.collection.delete_one({"_id": ObjectId(user_id)})
+        return result.deleted_count

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -21,7 +21,7 @@ def login():
             return render_template("login.html", username=username)
 
         # Minimal session payload; add more fields if you need them later
-        session["username"] = user.get("username")
+        session["username"] = user["username"]
         flash(f"Welcome, {session['username']}!", "success")
         # Redirect to a sensible default (update if you prefer another page)
         return redirect(url_for("main.show_home"))
@@ -36,3 +36,4 @@ def logout():
     session.clear()
     flash("You have been logged out.", "info")
     return redirect(url_for("auth.login"))
+

--- a/services/auth_service.py
+++ b/services/auth_service.py
@@ -1,49 +1,51 @@
 # services/auth_service.py
 from typing import Optional, Dict, Any
 from werkzeug.security import generate_password_hash, check_password_hash
-from config.database import mongodb
+
+from domain.models.user import User
+from repositories.users_repository import UserRepository
 
 
 def authenticate(username: str, password: str) -> Optional[Dict[str, Any]]:
     """Return user doc if username/password are valid; otherwise None."""
-    # TODO: user = mongodb.db()[get_user_by_username(username)]
-    # if not user:
-    #     return None
-    # pw_hash = user.get("password_hash")
-    # if not pw_hash:
-    #     return None
-    # return user if check_password_hash(pw_hash, password) else None
+    repo = UserRepository()
+    user = repo.get_by_username(username)
+    if not user:
+        return None
+    if not check_password_hash(user.password_hash, password):
+        return None
+    return user.model_dump(exclude={"password_hash"})
 
 
 def register_user(username: str, password: str, **extra) -> str:
     """Create a new user with a hashed password. Raises on duplicate username."""
-    # TODO: Create user in MongoDB
-    return "User created"
-    # if mongodb_connection.user_exists(username):
-    #     raise ValueError("Username already exists")
-    # pw_hash = generate_password_hash(password)
-    # return mongodb_connection.create_user(username, pw_hash, **extra)
+    repo = UserRepository()
+    if repo.get_by_username(username):
+        raise ValueError("Username already exists")
+    pw_hash = generate_password_hash(password)
+    user = User(username=username, password_hash=pw_hash, **extra)
+    return repo.create(user)
 
 
 def change_password(username: str, new_password: str) -> bool:
     """Set a new password for an existing user. Returns True if updated."""
-    # TODO: Update user in MongoDB
-    return "Password updated"
-    # if not mongodb_connection.user_exists(username):
-    #     return False
-    # pw_hash = generate_password_hash(new_password)
-    # return mongodb_connection.set_user_password_hash(username, pw_hash) == 1
+    repo = UserRepository()
+    user = repo.get_by_username(username)
+    if not user:
+        return False
+    pw_hash = generate_password_hash(new_password)
+    return repo.update(user.id, {"password_hash": pw_hash}) == 1
 
 
 def ensure_default_users() -> None:
     """Idempotently create the initial admin users with hashed passwords."""
-    # TODO: Create users in MongoDB
-    # defaults = [
-    #     ("nikola",  "N1k0l!ca"),
-    #     ("marija",  "Marij@ci"),
-    #     ("andrej",  "m@sterMind"),
-    # ]
-    # for username, raw_pw in defaults:
-    #     if not mongodb_connection.user_exists(username):
-    #         pw_hash = generate_password_hash(raw_pw)
-    #         mongodb_connection.create_user(username, pw_hash)
+    repo = UserRepository()
+    defaults = [
+        ("nikola", "N1k0l!ca"),
+        ("marija", "Marij@ci"),
+        ("andrej", "m@sterMind"),
+    ]
+    for username, raw_pw in defaults:
+        if not repo.get_by_username(username):
+            pw_hash = generate_password_hash(raw_pw)
+            repo.create(User(username=username, password_hash=pw_hash))


### PR DESCRIPTION
## Summary
- add `User` model with hashed password field
- implement `UserRepository` with username index and CRUD helpers
- wire authentication service and routes
- restrict application routes to logged in users and register blueprints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba99c86668832280a3523a00c3bd3a