### PR TITLE
Implement dashboard statistics service and route

### DIFF
--- a/routes/main.py
+++ b/routes/main.py
@@ -1,30 +1,20 @@
 # routes/main.py
-from flask import Blueprint, render_template, url_for
-from config.database import mongodb
+"""Routes for the landing page.
+
+The home page provides a quick overview of the database content. To keep the
+route lean, the heavy lifting (counting documents and fetching the latest
+event) lives in ``services.main_service``.
+"""
+
+from flask import Blueprint, render_template
+
+from services.main_service import fetch_main_stats
 
 main_bp = Blueprint("main", __name__)
 
 @main_bp.route("/")
 def show_home():
-    # TODO: Fetch stats
-    # participants_col = mongodb.db()['participants']
-    # events_col = mongodb.db()['events']
-    # countries_col = mongodb.db()['countries']
+    """Render the application dashboard with basic statistics."""
 
-    # stats = {
-    #     "participants": participants_col.count_documents({}),
-    #     "events": events_col.count_documents({}),
-    #     "countries": countries_col.count_documents({}),
-    # }
-
-    # optional: latest event
-    # latest_event = events_col.find().sort("dateFrom", -1).limit(1)
-    # latest = next(latest_event, None)
-    # stats["latest_event"] = latest["title"] if latest and latest.get("title") else (latest["eid"] if latest else None)
-    # stats["latest_event_date"] = latest.get("dateFrom") if latest else None
-
-    stats = {}
-    stats["latest_event"] = ''
-    stats["latest_event_date"] = ''
-
+    stats = fetch_main_stats()
     return render_template("main.html", stats=stats)

--- a/services/main_service.py
+++ b/services/main_service.py
@@ -1,0 +1,52 @@
+"""Service helpers for the application's landing page.
+
+This module gathers lightweight statistics used by the home page dashboard:
+
+* total number of participants (documents in ``participants``)
+* total number of events
+* total number of countries
+* the most recently added event based on ``dateFrom``
+
+The functions are intentionally small and synchronous; if the application grows
+larger these can be moved into dedicated repository/service classes.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from config.database import mongodb
+
+
+def fetch_main_stats() -> Dict[str, Any]:
+    """Return basic counts and latest-event info for the dashboard.
+
+    The database schema is simple enough that we query MongoDB collections
+    directly here rather than via repository objects.
+    """
+
+    db = mongodb.db()
+    participants_col = db["participants"]
+    events_col = db["events"]
+    countries_col = db["countries"]
+
+    stats: Dict[str, Any] = {
+        "participants": participants_col.count_documents({}),
+        "events": events_col.count_documents({}),
+        "countries": countries_col.count_documents({}),
+        "latest_event": None,
+        "latest_event_date": None,
+    }
+
+    # Fetch newest event by start date
+    latest_cursor = events_col.find().sort("dateFrom", -1).limit(1)
+    latest_doc = next(latest_cursor, None)
+    if latest_doc:
+        stats["latest_event"] = latest_doc.get("title") or latest_doc.get("eid")
+        stats["latest_event_date"] = latest_doc.get("dateFrom")
+
+    return stats
+
+
+__all__ = ["fetch_main_stats"]
+

--- a/tests/test_main_service.py
+++ b/tests/test_main_service.py
@@ -1,0 +1,57 @@
+import os
+import sys
+
+# Ensure the project root is on sys.path for importing the services package
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def test_fetch_main_stats(monkeypatch):
+    """Verify that fetch_main_stats aggregates counts and the latest event."""
+
+    class DummyCursor:
+        def __init__(self, doc):
+            self.doc = doc
+
+        def sort(self, *_, **__):
+            return self
+
+        def limit(self, *_):
+            return iter([self.doc] if self.doc else [])
+
+    class DummyCollection:
+        def __init__(self, count, doc=None):
+            self._count = count
+            self._doc = doc
+
+        def count_documents(self, *_):
+            return self._count
+
+        def find(self, *_):
+            return DummyCursor(self._doc)
+
+    class DummyDB:
+        def __init__(self):
+            self.data = {
+                "participants": DummyCollection(10),
+                "events": DummyCollection(3, {"title": "Test Event", "dateFrom": "2024-05-01"}),
+                "countries": DummyCollection(2),
+            }
+
+        def __getitem__(self, name):
+            return self.data[name]
+
+    class DummyMongo:
+        def db(self):
+            return DummyDB()
+
+    import services.main_service as main_service
+    monkeypatch.setattr(main_service, "mongodb", DummyMongo())
+
+    stats = main_service.fetch_main_stats()
+
+    assert stats["participants"] == 10
+    assert stats["events"] == 3
+    assert stats["countries"] == 2
+    assert stats["latest_event"] == "Test Event"
+    assert stats["latest_event_date"] == "2024-05-01"
+


### PR DESCRIPTION
## Summary
- compute participant, event, and country counts plus latest event in new service
- render dashboard stats through main route
- add unit test for main stats service

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bae953c548832291db91c59e27c5dd