### PR TITLE
Refactor system routes into blueprint and auto-register

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,127 +1,23 @@
 import os
-from flask import Flask, jsonify
-from config.database import mongodb
-from repositories.country_repository import CountryRepository
-from middleware.auth import login_required
-from routes.auth import auth_bp
-from routes.main import main_bp
-from routes.participants import participants_bp
-from routes.events import events_bp
-from routes.tests import tests_bp
-from routes.participant_events import participant_events_bp
+import importlib
+import pkgutil
+
+from flask import Blueprint, Flask
 
 def create_app() -> Flask:
-    """
-    Flask application factory.
-    - Registers blueprints (later).
-    - Initializes extensions.
-    """
+    """Flask application factory."""
     app = Flask(__name__)
     app.secret_key = os.getenv("SECRET_KEY", "dev")
-    app.register_blueprint(auth_bp)
-    app.register_blueprint(main_bp)
-    app.register_blueprint(participants_bp)
-    app.register_blueprint(events_bp)
-    app.register_blueprint(tests_bp)
-    app.register_blueprint(participant_events_bp)
 
+    # Auto-register all blueprints defined in routes/*.py
+    from routes import __path__ as routes_path
 
-    @app.route("/health", methods=["GET"])
-    @login_required
-    def health_check():
-        """
-        Simple health-check route.
-        Verifies app is running and DB connection is alive.
-        """
-        try:
-            mongodb.client.admin.command("ping")
-            db_status = "ok"
-        except Exception as e:
-            db_status = f"error: {str(e)}"
-
-        return jsonify({
-            "status": "ok",
-            "database": db_status
-        }), 200
-
-
-    @app.route("/stats", methods=["GET"])
-    @login_required
-    def get_stats():
-        """
-        Get statistics about the database including counts of participants and countries.
-        """
-        try:
-            # Initialize repositories
-            country_repo = CountryRepository()
-            from repositories.participant_repository import ParticipantRepository
-            participant_repo = ParticipantRepository()
-
-            # Get counts
-            participants_count = participant_repo.collection.count_documents({})
-            countries_count = country_repo.collection.count_documents({})
-
-            return jsonify({
-                "status": "ok",
-                "participants_count": participants_count,
-                "countries_count": countries_count,
-                "message": "Successfully retrieved statistics"
-            }), 200
-
-        except Exception as e:
-            return jsonify({
-                "status": "error",
-                "message": f"Failed to retrieve statistics: {str(e)}"
-            }), 500
-
-    @app.route("/stats/detailed", methods=["GET"])
-    @login_required
-    def get_detailed_stats():
-        """
-        Get more detailed statistics about the database.
-        """
-        try:
-            # Initialize repositories
-            country_repo = CountryRepository()
-            from repositories.participant_repository import ParticipantRepository
-            participant_repo = ParticipantRepository()
-
-            # Get basic counts
-            participants_count = participant_repo.collection.count_documents({})
-            countries_count = country_repo.collection.count_documents({})
-
-            # Get counts by grade
-            from domain.models.participant import Grade
-            black_list_count = participant_repo.collection.count_documents({"grade": Grade.BLACK_LIST.value})
-            normal_count = participant_repo.collection.count_documents({"grade": Grade.NORMAL.value})
-            excellent_count = participant_repo.collection.count_documents({"grade": Grade.EXCELLENT.value})
-
-            # Get participants by country (top 5)
-            pipeline = [
-                {"$group": {"_id": "$representing_country", "count": {"$sum": 1}}},
-                {"$sort": {"count": -1}},
-                {"$limit": 5}
-            ]
-            participants_by_country = list(participant_repo.collection.aggregate(pipeline))
-
-            return jsonify({
-                "status": "ok",
-                "participants_count": participants_count,
-                "countries_count": countries_count,
-                "participants_by_grade": {
-                    "black_list": black_list_count,
-                    "normal": normal_count,
-                    "excellent": excellent_count
-                },
-                "top_countries": participants_by_country,
-                "message": "Successfully retrieved detailed statistics"
-            }), 200
-
-        except Exception as e:
-            return jsonify({
-                "status": "error",
-                "message": f"Failed to retrieve detailed statistics: {str(e)}"
-            }), 500
+    for _, module_name, _ in pkgutil.iter_modules(routes_path):
+        module = importlib.import_module(f"routes.{module_name}")
+        for attr_name in dir(module):
+            obj = getattr(module, attr_name)
+            if isinstance(obj, Blueprint):
+                app.register_blueprint(obj)
 
     return app
 

--- a/routes/system.py
+++ b/routes/system.py
@@ -1,0 +1,93 @@
+"""System endpoints (health check and stats)."""
+
+from flask import Blueprint, jsonify
+
+from config.database import mongodb
+from middleware.auth import login_required
+from repositories.country_repository import CountryRepository
+
+system_bp = Blueprint("system", __name__)
+
+
+@system_bp.route("/health", methods=["GET"])
+def health_check():
+    """Simple health-check route without authentication."""
+    try:
+        mongodb.client.admin.command("ping")
+        db_status = "ok"
+    except Exception as e:  # pragma: no cover - best effort
+        db_status = f"error: {str(e)}"
+
+    return jsonify({
+        "status": "ok",
+        "database": db_status,
+    }), 200
+
+
+@system_bp.route("/stats", methods=["GET"])
+@login_required
+def get_stats():
+    """Return basic database statistics."""
+    try:
+        country_repo = CountryRepository()
+        from repositories.participant_repository import ParticipantRepository
+
+        participant_repo = ParticipantRepository()
+        participants_count = participant_repo.collection.count_documents({})
+        countries_count = country_repo.collection.count_documents({})
+
+        return jsonify({
+            "status": "ok",
+            "participants_count": participants_count,
+            "countries_count": countries_count,
+            "message": "Successfully retrieved statistics",
+        }), 200
+    except Exception as e:  # pragma: no cover - best effort
+        return jsonify({
+            "status": "error",
+            "message": f"Failed to retrieve statistics: {str(e)}",
+        }), 500
+
+
+@system_bp.route("/stats/detailed", methods=["GET"])
+@login_required
+def get_detailed_stats():
+    """Return detailed database statistics."""
+    try:
+        country_repo = CountryRepository()
+        from repositories.participant_repository import ParticipantRepository
+
+        participant_repo = ParticipantRepository()
+        participants_count = participant_repo.collection.count_documents({})
+        countries_count = country_repo.collection.count_documents({})
+
+        from domain.models.participant import Grade
+
+        black_list_count = participant_repo.collection.count_documents({"grade": Grade.BLACK_LIST.value})
+        normal_count = participant_repo.collection.count_documents({"grade": Grade.NORMAL.value})
+        excellent_count = participant_repo.collection.count_documents({"grade": Grade.EXCELLENT.value})
+
+        pipeline = [
+            {"$group": {"_id": "$representing_country", "count": {"$sum": 1}}},
+            {"$sort": {"count": -1}},
+            {"$limit": 5},
+        ]
+        participants_by_country = list(participant_repo.collection.aggregate(pipeline))
+
+        return jsonify({
+            "status": "ok",
+            "participants_count": participants_count,
+            "countries_count": countries_count,
+            "participants_by_grade": {
+                "black_list": black_list_count,
+                "normal": normal_count,
+                "excellent": excellent_count,
+            },
+            "top_countries": participants_by_country,
+            "message": "Successfully retrieved detailed statistics",
+        }), 200
+    except Exception as e:  # pragma: no cover - best effort
+        return jsonify({
+            "status": "error",
+            "message": f"Failed to retrieve detailed statistics: {str(e)}",
+        }), 500


### PR DESCRIPTION
## Summary
- add `system_bp` blueprint with `/health`, `/stats`, and `/stats/detailed`
- remove login requirement from `/health`
- auto-register all blueprints under `routes/` in `create_app`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb59e3308c8322aa6aefc53f228211