### PR TITLE
Add Excel import blueprint and tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,11 @@ def create_app() -> Flask:
     app = Flask(__name__)
     app.secret_key = os.getenv("SECRET_KEY", "dev")
 
+    # Configure uploads directory for temporary Excel files
+    uploads_dir = os.getenv("UPLOADS_DIR", os.path.join(os.getcwd(), "uploads"))
+    app.config["UPLOADS_DIR"] = uploads_dir
+    os.makedirs(uploads_dir, exist_ok=True)
+
     # Auto-register all blueprints defined in routes/*.py
     from routes import __path__ as routes_path
 

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -1,0 +1,117 @@
+"""Blueprint routes for importing Excel files.
+
+This module provides a small flow:
+- GET  /import          → show the upload page
+- POST /import          → accept a file, validate required tables, show confirmation
+- POST /import/proceed  → (dry-run) parse after confirmation; prints to logs / shows result
+- POST /import/discard  → remove previously uploaded file
+
+Notes:
+- No database writes should occur here (dry-run / preview only).
+- Keep endpoint names aligned with templates: use `url_for('imports.upload_check')` and
+  `url_for('imports.proceed_parse')` in forms.
+"""
+
+import os
+from flask import Blueprint, render_template, request, current_app, flash, redirect, url_for, abort
+from werkzeug.utils import secure_filename
+from middleware.auth import login_required
+from services.import_service import validate_excel_file_for_import, inspect_and_preview_uploaded
+
+imports_bp = Blueprint("imports", __name__, url_prefix="/import")
+
+ALLOWED_EXTENSIONS = {"xlsx", "xls"}
+
+def allowed_file(filename: str) -> bool:
+    """Return True if filename has an allowed spreadsheet extension."""
+    return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
+
+def _uploads_path(filename: str) -> str:
+    """Return absolute path in UPLOADS_DIR for filename; prevents path traversal."""
+    safe = secure_filename(filename)
+
+    folder = current_app.config["UPLOADS_DIR"]
+    fullpath = os.path.abspath(os.path.join(folder, safe))
+    if not fullpath.startswith(os.path.abspath(folder) + os.sep):
+        abort(400, "Invalid filename")
+    return fullpath
+
+@imports_bp.route("", methods=["GET"], endpoint="upload_form")
+@login_required
+def upload_form():
+    """Render the upload/validation entry page."""
+    return render_template("import_upload.html")
+
+@imports_bp.route("", methods=["POST"], endpoint="upload_check")
+@login_required
+def upload_check():
+    """Handle upload: save file, verify required Excel tables, and show confirmation."""
+
+    if "file" not in request.files:
+        flash("No file part", "warning")
+        return redirect(url_for("imports.upload_form"))
+
+    file = request.files["file"]
+    if file.filename == "":
+        flash("No file selected", "warning")
+        return redirect(url_for("imports.upload_form"))
+
+    if not allowed_file(file.filename):
+        flash("Invalid file type. Please upload .xlsx or .xls", "danger")
+        return redirect(url_for("imports.upload_form"))
+
+    safe_name = secure_filename(file.filename)
+    dest = _uploads_path(safe_name)
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    file.save(dest)
+
+    ok, missing, _tables = validate_excel_file_for_import(dest)
+
+    if ok:
+        return render_template("import_check.html", filename=safe_name, status="ok")
+    else:
+        try:
+            os.remove(dest)
+        except Exception:
+            pass
+        return render_template("import_check.html", filename=safe_name, status="bad", missing=missing)
+
+@imports_bp.route("/proceed", methods=["POST"], endpoint="proceed_parse")
+@login_required
+def proceed_parse():
+    """Parse the previously uploaded file (dry run) and log findings; no DB writes."""
+    filename = request.form.get("filename", "")
+    if not filename:
+        flash("Missing filename for parsing.", "warning")
+        return redirect(url_for("imports.upload_form"))
+
+    path = _uploads_path(filename)
+    if not os.path.exists(path):
+        flash("Uploaded file not found.", "warning")
+        return redirect(url_for("imports.upload_form"))
+
+    try:
+        print(f"[INFO] Parsing uploaded Excel: {path}")
+        inspect_and_preview_uploaded(path)
+        flash("Parsed successfully. Check server logs for details.", "success")
+    except Exception as e:
+        flash(f"Parsing failed: {e}", "danger")
+
+    return redirect(url_for("imports.upload_form"))
+
+@imports_bp.route("/discard", methods=["POST"], endpoint="discard_file")
+@login_required
+def discard_file():
+    """Delete a previously uploaded file from the uploads folder."""
+    filename = request.form.get("filename", "")
+    if not filename:
+        flash("Nothing to discard.", "info")
+        return redirect(url_for("imports.upload_form"))
+    path = _uploads_path(filename)
+    try:
+        if os.path.exists(path):
+            os.remove(path)
+            flash(f"Discarded file: {filename}", "info")
+    except Exception as e:
+        flash(f"Failed to discard: {e}", "danger")
+    return redirect(url_for("imports.upload_form"))

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -177,24 +177,29 @@ def _parse_event_header(a1: str, a2: str, year: int):
 # ============================
 
 def _country_id(name: str) -> Optional[str]:
-    """Get the country _id for name, inserting a new country if not present."""
-    # TODO: return (doc is not None), (doc or {})
-    return None
-    #  doc = mongodb_connection.countries.find_one({"country": country})
-    # return doc["_id"] if doc else None
+    """Return the country _id for `name`, or None if not found."""
+    if not name:
+        return None
+    try:
+        doc = mongodb.collection('countries').find_one({'country': name})
+        return doc.get('_id') if doc else None
+    except Exception:
+        # Avoid raising during preview; treat missing/DB errors as not found
+        return None
 
 def _participant_exists(name_display: str, country_name: str):
     """
     Existence check by normalized app name (First ... LAST) + country_id if available.
     """
-    #TODO: return (doc is not None), (doc or {})
-    return False, {}
-    # q = {"name": _to_app_display_name(name_display)}
-    # cid = _country_id(country_name)
-    # if cid is not None:
-    #     q["country_id"] = cid
-    # doc = mongodb_connection.participants.find_one(q)
-    # return (doc is not None), (doc or {})
+    q = {"name": _to_app_display_name(name_display)}
+    cid = _country_id(country_name)
+    if cid is not None:
+        q["country_id"] = cid
+    try:
+        doc = mongodb.collection('participants').find_one(q)
+        return (doc is not None), (doc or {})
+    except Exception:
+        return False, {}
 
 
 # ============================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,14 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import types
 def _make_dummy_db():
     class DummyCollection:
+        def find_one(self, *args, **kwargs):
+            return None
         def create_index(self, *args, **kwargs):
             pass
     class DummyMongoConn:
         def __getitem__(self, name):
+            return DummyCollection()
+        def collection(self, name):
             return DummyCollection()
     return DummyMongoConn()
 

--- a/tests/test_import_routes.py
+++ b/tests/test_import_routes.py
@@ -1,0 +1,79 @@
+import os
+from io import BytesIO
+
+import pytest
+from openpyxl import Workbook
+from openpyxl.worksheet.table import Table, TableStyleInfo
+
+from app import create_app
+
+
+def _build_workbook_bytes(valid: bool) -> bytes:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Participants"
+    ws["A1"] = "E1 Title"
+    ws["A2"] = "2024"
+
+    if valid:
+        ws_list = wb.create_sheet("List")
+        ws_list.append(["Name", "Position"])
+        ws_list.append(["Doe John", "Leader"])
+        tbl = Table(displayName="ParticipantsLista", ref="A1:B2")
+        tbl.tableStyleInfo = TableStyleInfo(name="TableStyleMedium9", showRowStripes=True)
+        ws_list.add_table(tbl)
+
+        ws_country = wb.create_sheet("Alb")
+        ws_country.append(["Name", "Grade"])
+        ws_country.append(["John Doe", "10"])
+        tbl2 = Table(displayName="tableAlb", ref="A1:B2")
+        tbl2.tableStyleInfo = TableStyleInfo(name="TableStyleMedium9", showRowStripes=True)
+        ws_country.add_table(tbl2)
+
+    stream = BytesIO()
+    wb.save(stream)
+    return stream.getvalue()
+
+
+@pytest.fixture
+def client(tmp_path):
+    app = create_app()
+    app.config["TESTING"] = True
+    app.config["UPLOADS_DIR"] = tmp_path
+    os.makedirs(tmp_path, exist_ok=True)
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["username"] = "tester"
+        yield client
+
+
+def test_upload_valid_file(client):
+    data = {"file": (BytesIO(_build_workbook_bytes(True)), "sample.xlsx")}
+    resp = client.post("/import", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 200
+    assert b"File is OK" in resp.data
+
+
+def test_upload_invalid_file(client):
+    data = {"file": (BytesIO(_build_workbook_bytes(False)), "bad.xlsx")}
+    resp = client.post("/import", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 200
+    assert b"File is not formatted correctly" in resp.data
+
+
+def test_proceed_and_discard(client, tmp_path):
+    content = _build_workbook_bytes(True)
+    path = tmp_path / "sample.xlsx"
+    with open(path, "wb") as fh:
+        fh.write(content)
+
+    resp = client.post("/import/proceed", data={"filename": "sample.xlsx"})
+    assert resp.status_code == 302
+
+    # recreate file for discard test
+    with open(path, "wb") as fh:
+        fh.write(content)
+    assert path.exists()
+    resp = client.post("/import/discard", data={"filename": "sample.xlsx"})
+    assert resp.status_code == 302
+    assert not path.exists()


### PR DESCRIPTION
## Summary
- Implement Excel import blueprint with upload, dry-run parse, and discard endpoints
- Configure application uploads directory
- Add Mongo lookup helpers for countries and participants
- Introduce route tests covering upload, parse, and discard flows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf20872c908322a52210a25635fa3e