### PR TITLE
Consolidate participant name field

### DIFF
--- a/domain/models/participant.py
+++ b/domain/models/participant.py
@@ -50,10 +50,8 @@ class Participant(BaseModel):
     gender: Gender
     grade: Grade = Field(default=Grade.NORMAL, description="Participant grade: 0=Black List, 1=Normal, 2=Excellent")
 
-    # Name fields
-    first_name: str = Field(..., min_length=1)
-    middle_name: Optional[str] = None
-    last_name: str = Field(..., min_length=1)
+    # Name field
+    name: str = Field(..., min_length=1)
 
     # Birth / citizenship - all use Country CID references
     dob: date
@@ -96,10 +94,13 @@ class Participant(BaseModel):
 
     # ---------- Validators ----------
 
-    @field_validator("last_name", mode="after")
+    @field_validator("name", mode="after")
     @classmethod
-    def _uppercase_lastname(cls, v: str) -> str:
-        return v.upper()
+    def _normalize_name(cls, v: str) -> str:
+        parts = v.split()
+        if parts:
+            parts[-1] = parts[-1].upper()
+        return " ".join(parts)
 
     @field_validator("citizenships", mode="before")
     @classmethod

--- a/routes/events.py
+++ b/routes/events.py
@@ -21,6 +21,12 @@ def api_list_events():
     return jsonify([e.model_dump(by_alias=True) for e in events])
 
 
+@events_bp.get("/list")
+def show_events():
+    """Alias endpoint for listing events (used by templates)."""
+    return api_list_events()
+
+
 @events_bp.post("/")
 def api_create_event():
     data = request.get_json() or {}

--- a/routes/imports.py
+++ b/routes/imports.py
@@ -24,19 +24,19 @@ def _allowed_file(filename: str) -> bool:
 
 def _upload_dir() -> str:
     # Fallback to ./uploads if not configured
-    d = current_app.config.get("UPLOAD_FOLDER", os.path.join(os.getcwd(), "uploads"))
+    d = current_app.config.get("UPLOADS_DIR", os.path.join(os.getcwd(), "uploads"))
     os.makedirs(d, exist_ok=True)
     return d
 
 
-@imports_bp.get("/")
+@imports_bp.get("/", strict_slashes=False)
 @login_required
 def upload_form():
     # Simple file chooser form
     return render_template("import_upload.html")
 
 
-@imports_bp.post("/")
+@imports_bp.post("/", strict_slashes=False)
 @login_required
 def upload_check():
     """

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,7 +24,7 @@
         </li>
         <li class="nav-item">
             <a class="nav-link{% if request.endpoint and request.endpoint.startswith('events.') %} active{% endif %}"
-             href="{{ url_for('events.api_list_events') }}">Events</a>
+             href="{{ url_for('events.show_events') }}">Events</a>
         </li>
         <li class="nav-item">
             <a class="nav-link{% if request.endpoint and request.endpoint.startswith('imports.') %} active{% endif %}"


### PR DESCRIPTION
## Summary
- Replace separate first, middle, and last name fields with a single `name` on participants
- Uppercase the surname via a name validator and update import workflow to populate `name`
- Adjust templates and routes to reference new endpoints and handle uploads configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf439116488322ba81cd062cef8a70