### PR TITLE
Add loading overlay for form submissions

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,4 +1,12 @@
 document.addEventListener('DOMContentLoaded', function() {
-    // Add any client-side functionality here
     console.log('Participants interface loaded');
+
+    const overlay = document.getElementById('loadingOverlay');
+    if (overlay) {
+        document.querySelectorAll('form').forEach(form => {
+            form.addEventListener('submit', function() {
+                overlay.style.display = 'flex';
+            });
+        });
+    }
 });

--- a/static/style.css
+++ b/static/style.css
@@ -22,3 +22,16 @@ th a {
     justify-content: center;
     margin-top: 20px;
 }
+
+.loading-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 1050;
+    display: none;
+    align-items: center;
+    justify-content: center;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -51,6 +51,12 @@
     </div>
   </div>
 </nav>
+
+<div id="loadingOverlay" class="loading-overlay">
+  <div class="spinner-border text-light" role="status">
+    <span class="visually-hidden">Loading...</span>
+  </div>
+</div>
 <div class="container mt-3">
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
@@ -71,5 +77,6 @@
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/static/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a global loading overlay spinner in base template
- style overlay and load spinner script
- show overlay when any form is submitted

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf47659d088322913f4aa8983a70a1