### PR TITLE
Improve name variant lookups during import

### DIFF
--- a/tests/test_import_name_variants.py
+++ b/tests/test_import_name_variants.py
@@ -1,0 +1,59 @@
+from io import BytesIO
+
+from openpyxl import Workbook
+from openpyxl.worksheet.table import Table, TableStyleInfo
+
+import services.import_service as import_service
+
+
+def _build_workbook_bytes() -> bytes:
+    """Construct a minimal workbook containing the required tables."""
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Participants"
+    ws["A1"] = "E1 TITLE"
+    ws["A2"] = "JUNE 1 - 3 - Zagreb"
+
+    # ParticipantsLista with position/phone/email
+    ws_list = wb.create_sheet("List")
+    ws_list.append(["Name (Latin)", "Position", "Phone", "Email"])
+    ws_list.append(["BAJIĆ BRALIĆ, Ana Marija", "Advisor", "123", "ana@example.com"])
+    tbl_list = Table(displayName="ParticipantsLista", ref="A1:D2")
+    tbl_list.tableStyleInfo = TableStyleInfo(name="TableStyleMedium9", showRowStripes=True)
+    ws_list.add_table(tbl_list)
+
+    # MAIN ONLINE → ParticipantsList (minimal)
+    ws_online = wb.create_sheet("MAIN ONLINE")
+    ws_online.append(["Name", "Middle name", "Last name", "Email address", "Phone number", "Position"])
+    ws_online.append(["Ana", "Marija", "BAJIĆ BRALIĆ", "ana@example.com", "123", "Advisor"])
+    tbl_online = Table(displayName="ParticipantsList", ref="A1:F2")
+    tbl_online.tableStyleInfo = TableStyleInfo(name="TableStyleMedium9", showRowStripes=True)
+    ws_online.add_table(tbl_online)
+
+    # Country table with the attendee
+    ws_country = wb.create_sheet("Cro")
+    ws_country.append(["Name and last name", "Grade"])
+    ws_country.append(["BAJIĆ BRALIĆ, Ana Marija", ""])
+    tbl_country = Table(displayName="tableCro", ref="A1:B2")
+    tbl_country.tableStyleInfo = TableStyleInfo(name="TableStyleMedium9", showRowStripes=True)
+    ws_country.add_table(tbl_country)
+
+    stream = BytesIO()
+    wb.save(stream)
+    return stream.getvalue()
+
+
+def test_bajic_bralic_lookup(tmp_path):
+    content = _build_workbook_bytes()
+    path = tmp_path / "sample.xlsx"
+    with open(path, "wb") as fh:
+        fh.write(content)
+
+    result = import_service.parse_for_commit(str(path))
+    attendees = result["attendees"]
+    assert len(attendees) == 1
+    attendee = attendees[0]
+    assert attendee["position"] == "Advisor"
+    assert attendee["phone"] == "123"
+    assert attendee["email"] == "ana@example.com"
+


### PR DESCRIPTION
## Summary
- generate multiple (first, middle, last) combinations treating last 1-3 tokens as surname candidates
- pick the first variant that matches online or position lookups when enriching attendees
- test import with name "BAJIĆ BRALIĆ, Ana Marija" to ensure position/phone/email are captured

## Testing
- `pytest tests/test_import_name_variants.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pydantic==2.7.3` *(fails: the configured Python interpreter version (3.13) is newer than PyO3's maximum supported version (3.12))*

------
https://chatgpt.com/codex/tasks/task_e_68bfdb7b35e4832286a34613804b122d