### PR TITLE
Prefer country table name over ParticipantsList name

### DIFF
--- a/services/import_service.py
+++ b/services/import_service.py
@@ -333,8 +333,8 @@ def parse_for_commit(path: str) -> dict:
             # ✅ always fall back to {} so .get(...) is safe
             # (p_list and p_comp already default to {})
 
-            # Determine name and display
-            base_name = p_list.get("name") or " ".join([first, middle, last]).strip()
+            # Determine name and display solely from country table tokens
+            base_name = " ".join([first, middle, last]).strip()
             name_display = _to_app_display_name(base_name)
 
             # Compose attendee record

--- a/tests/test_import_name_variants.py
+++ b/tests/test_import_name_variants.py
@@ -25,7 +25,9 @@ def _build_workbook_bytes() -> bytes:
     # MAIN ONLINE → ParticipantsList (minimal)
     ws_online = wb.create_sheet("MAIN ONLINE")
     ws_online.append(["Name", "Middle name", "Last name", "Email address", "Phone number", "Position"])
-    ws_online.append(["Ana", "Marija", "BAJIĆ BRALIĆ", "ana@example.com", "123", "Advisor"])
+    # ParticipantsList entry deliberately omits accents to ensure country-table
+    # spelling is preserved in the output
+    ws_online.append(["Ana", "Marija", "Bajic Bralic", "ana@example.com", "123", "Advisor"])
     tbl_online = Table(displayName="ParticipantsList", ref="A1:F2")
     tbl_online.tableStyleInfo = TableStyleInfo(name="TableStyleMedium9", showRowStripes=True)
     ws_online.add_table(tbl_online)
@@ -53,6 +55,7 @@ def test_bajic_bralic_lookup(tmp_path):
     attendees = result["attendees"]
     assert len(attendees) == 1
     attendee = attendees[0]
+    assert attendee["name"] == "Ana Marija BAJIĆ BRALIĆ"
     assert attendee["position"] == "Advisor"
     assert attendee["phone"] == "123"
     assert attendee["email"] == "ana@example.com"


### PR DESCRIPTION
## Summary
- Use country table tokens for attendee name instead of ParticipantsList name
- Add regression test to ensure country table spelling is preserved even when ParticipantsList match exists

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfe61e46fc8322bfcbafd42e5eacad