### PR TITLE
Normalize name keys via canonical Unicode forms

### DIFF
--- a/tests/test_name_normalization.py
+++ b/tests/test_name_normalization.py
@@ -1,0 +1,15 @@
+import services.import_service as import_service
+
+
+def test_vucetaj_variants_same_key():
+    key1 = import_service._name_key("VUÇETAJ", "Gani")
+    key2 = import_service._name_key("Vuçetaj", "Gani")
+    key3 = import_service._name_key("Vucetaj", "Gani")
+    assert key1 == key2 == key3
+
+
+def test_kujaca_variants_same_key():
+    key1 = import_service._name_key("Kujača", "Miro")
+    key2 = import_service._name_key("Kujaca", "Miro")
+    key3 = import_service._name_key("KUJACA", "MIRO")
+    assert key1 == key2 == key3


### PR DESCRIPTION
## Summary
- add `_canon` to strip accents with NFD normalization and lowercase
- use `_canon` in `_name_key`, `_split_name_variants`, and lookup key generation
- add tests ensuring variants like "VUÇETAJ" and "Kujaca" share identical keys

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bff93fbae08322a1577314d9135e09