### PR TITLE
Return initial attendee list

### DIFF
--- a/routes/imports.py
+++ b/routes/imports.py
@@ -112,12 +112,21 @@ def proceed_parse():
             }
             for attendee in participants_raw
         ]
+        initial_raw = payload.get("initial_attendees", [])
+        initial_attendees = [
+            {
+                k: v.isoformat() if isinstance(v, (datetime, date)) else v
+                for k, v in attendee.items()
+            }
+            for attendee in initial_raw
+        ]
         with open(preview_path, "w", encoding="utf-8") as fh:
             json.dump(
                 {
                     "event": event_clean,
                     "participants": participants,
                     "participants_count": len(participants),
+                    "initial_attendees": initial_attendees,
                     "generated_at": datetime.utcnow().isoformat() + "Z",
                 },
                 fh,

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -264,6 +264,7 @@ def parse_for_commit(path: str) -> dict:
       - attendees: [ {name_display, name,
                       representing_country, transportation, travelling_from, grade,
                       position, phone, email, ...plus MAIN ONLINE fields when present} ]
+      - initial_attendees: base attendee records prior to enrichment
     """
     # 1) Event header
     wb = openpyxl.load_workbook(path, data_only=True)
@@ -318,7 +319,7 @@ def parse_for_commit(path: str) -> dict:
 
         for _, row in df.iterrows():
             raw_name = _normalize(str(row.get(nm_col, ""))) if nm_col else ""
-            if not raw_name:
+            if not raw_name or raw_name.upper() == "TOTAL":
                 continue
 
             transportation = _normalize(str(row.get(trans_col, ""))) if trans_col else ""
@@ -434,6 +435,7 @@ def parse_for_commit(path: str) -> dict:
             "location": location,
         },
         "attendees": attendees,
+        "initial_attendees": initial_attendees,
     }
 
 

--- a/tests/test_import_name_variants.py
+++ b/tests/test_import_name_variants.py
@@ -57,7 +57,8 @@ def _build_workbook_bytes() -> bytes:
     ws_country = wb.create_sheet("Cro")
     ws_country.append(["Name and last name", "Grade"])
     ws_country.append(["BAJIĆ BRALIĆ, Ana Marija", ""])
-    tbl_country = Table(displayName="tableCro", ref="A1:B2")
+    ws_country.append(["TOTAL", ""])
+    tbl_country = Table(displayName="tableCro", ref="A1:B3")
     tbl_country.tableStyleInfo = TableStyleInfo(name="TableStyleMedium9", showRowStripes=True)
     ws_country.add_table(tbl_country)
 
@@ -102,4 +103,8 @@ def test_bajic_bralic_lookup(tmp_path):
     assert attendee["iban"] == "XK051920315886321195"
     assert attendee["iban_type"] == "EURO"
     assert attendee["swift"] == "NCBA XK PR"
+
+    initial = result.get("initial_attendees", [])
+    assert len(initial) == 1
+    assert initial[0]["name"] == "Ana Marija BAJIĆ BRALIĆ"
 


### PR DESCRIPTION
## Summary
- expose `initial_attendees` from `parse_for_commit` and skip summary rows
- include raw attendee list in import preview JSON
- cover initial attendees in tests and ignore TOTAL rows

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c02208279c8322852bd2b4b515b721