### PR TITLE
Add import preview page for events and participants

### DIFF
--- a/templates/import_preview.html
+++ b/templates/import_preview.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block title %}Import Preview{% endblock %}
+{% block content %}
+<h2>Event Preview</h2>
+{% if event %}
+  <dl class="row">
+    <dt class="col-sm-2">Event ID</dt>
+    <dd class="col-sm-10">{{ event.eid }}</dd>
+    <dt class="col-sm-2">Title</dt>
+    <dd class="col-sm-10">{{ event.title }}</dd>
+    <dt class="col-sm-2">Dates</dt>
+    <dd class="col-sm-10">{{ event.date_from or '' }}{% if event.date_to %} - {{ event.date_to }}{% endif %}</dd>
+    <dt class="col-sm-2">Location</dt>
+    <dd class="col-sm-10">{{ event.location }}</dd>
+  </dl>
+{% else %}
+  <p>No event data available.</p>
+{% endif %}
+
+<h3>Participants ({{ participants|length }})</h3>
+<table class="table table-striped table-sm">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Country</th>
+      <th>Grade</th>
+      <th>Position</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for p in participants %}
+    <tr>
+      <td>{{ p.name_display }}</td>
+      <td>{{ p.representing_country }}</td>
+      <td>{{ p.grade }}</td>
+      <td>{{ p.position }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<a class="btn btn-secondary" href="{{ url_for('imports.upload_form') }}">Back</a>
+{% endblock %}

--- a/tests/test_import_routes.py
+++ b/tests/test_import_routes.py
@@ -23,6 +23,13 @@ def _build_workbook_bytes(valid: bool) -> bytes:
         tbl.tableStyleInfo = TableStyleInfo(name="TableStyleMedium9", showRowStripes=True)
         ws_list.add_table(tbl)
 
+        ws_online = wb.create_sheet("MAIN ONLINE")
+        ws_online.append(["Name"])
+        ws_online.append(["Dummy"])
+        tbl_online = Table(displayName="ParticipantsList", ref="A1:A2")
+        tbl_online.tableStyleInfo = TableStyleInfo(name="TableStyleMedium9", showRowStripes=True)
+        ws_online.add_table(tbl_online)
+
         ws_country = wb.create_sheet("Alb")
         ws_country.append(["Name", "Grade"])
         ws_country.append(["John Doe", "10"])
@@ -69,6 +76,11 @@ def test_proceed_and_discard(client, tmp_path):
 
     resp = client.post("/import/proceed", data={"filename": "sample.xlsx"})
     assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/import/preview/sample.preview.json")
+
+    preview_resp = client.get("/import/preview/sample.preview.json")
+    assert preview_resp.status_code == 200
+    assert b"Participants" in preview_resp.data
 
     # recreate file for discard test
     with open(path, "wb") as fh:


### PR DESCRIPTION
## Summary
- Generate preview JSON redirecting to a new preview page after import
- Display event details and attendee table from preview JSON
- Cover new preview workflow with updated tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c038bcced483228df74c6a2fdf5114