### PR TITLE
Omit initial attendees from import preview

### DIFF
--- a/routes/imports.py
+++ b/routes/imports.py
@@ -112,21 +112,13 @@ def proceed_parse():
             }
             for attendee in participants_raw
         ]
-        initial_raw = payload.get("initial_attendees", [])
-        initial_attendees = [
-            {
-                k: v.isoformat() if isinstance(v, (datetime, date)) else v
-                for k, v in attendee.items()
-            }
-            for attendee in initial_raw
-        ]
+
         with open(preview_path, "w", encoding="utf-8") as fh:
             json.dump(
                 {
                     "event": event_clean,
                     "participants": participants,
                     "participants_count": len(participants),
-                    "initial_attendees": initial_attendees,
                     "generated_at": datetime.utcnow().isoformat() + "Z",
                 },
                 fh,

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -52,7 +52,7 @@ MONTHS: Dict[str, int] = {
     "JULY": 7, "AUGUST": 8, "SEPTEMBER": 9, "OCTOBER": 10, "NOVEMBER": 11, "DECEMBER": 12
 }
 
-DEBUG_PRINT = True  # flip to False to quiet logs after you’re happy
+DEBUG_PRINT = False  # flip to True for verbose logging and extra debug data
 
 # --- ADD near the top with other constants ---
 # We now require the full roster table for enrichment:
@@ -271,7 +271,8 @@ def parse_for_commit(path: str) -> dict:
       - attendees: [ {name_display, name,
                       representing_country, transportation, travelling_from, grade,
                       position, phone, email, ...plus MAIN ONLINE fields when present} ]
-      - initial_attendees: base attendee records prior to enrichment
+    The raw attendee records (``initial_attendees``) are collected only when
+    ``DEBUG_PRINT`` is enabled and otherwise omitted from the returned payload.
     """
     # 1) Event header
     wb = openpyxl.load_workbook(path, data_only=True)
@@ -433,7 +434,7 @@ def parse_for_commit(path: str) -> dict:
         for rec in initial_attendees:
             print("  ", rec)
 
-    return {
+    payload = {
         "event": {
             "eid": eid,
             "title": title,
@@ -442,8 +443,12 @@ def parse_for_commit(path: str) -> dict:
             "location": location,
         },
         "attendees": attendees,
-        "initial_attendees": initial_attendees,
     }
+
+    if DEBUG_PRINT:
+        payload["initial_attendees"] = initial_attendees
+
+    return payload
 
 
 # ============================

--- a/tests/test_import_name_variants.py
+++ b/tests/test_import_name_variants.py
@@ -104,7 +104,6 @@ def test_bajic_bralic_lookup(tmp_path):
     assert attendee["iban_type"] == "EURO"
     assert attendee["swift"] == "NCBA XK PR"
 
-    initial = result.get("initial_attendees", [])
-    assert len(initial) == 1
-    assert initial[0]["name"] == "Ana Marija BAJIĆ BRALIĆ"
+    # Ensure debug-only data is not present by default
+    assert "initial_attendees" not in result
 


### PR DESCRIPTION
## Summary
- Gate `initial_attendees` behind `DEBUG_PRINT` in import parsing
- Stop serializing `initial_attendees` in `/import/proceed` preview JSON
- Update tests to ensure parsed events exclude `initial_attendees`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c12e6642948322b80febd3da49a2a6