### PR TITLE
Fix event page titles and clean up placeholders

### DIFF
--- a/templates/event_detail.html
+++ b/templates/event_detail.html
@@ -1,11 +1,9 @@
 {% extends "base.html" %}
 
-{% block title %}Participants{% endblock %}
+{% block title %}Event Details{% endblock %}
 
 {% block content %}
   <h1 class="mb-4">Event details</h1>
-  <!-- your existing search, table, pagination -->
-
 
 <div class="container mt-4">
   <h2 class="mb-3">{{ event.title or event.eid }}</h2>

--- a/templates/events.html
+++ b/templates/events.html
@@ -1,14 +1,10 @@
 {% extends "base.html" %}
 
-{% block title %}Participants{% endblock %}
+{% block title %}Events{% endblock %}
 
 {% block content %}
-  <h1 class="mb-4">Participants</h1>
-  <!-- your existing search, table, pagination -->
-
-
-<div class="container mt-4">
-  <h1 class="mb-4">Events</h1>
+  <div class="container mt-4">
+    <h1 class="mb-4">Events</h1>
 
   <!-- Search -->
   <form class="mb-4">


### PR DESCRIPTION
## Summary
- Correct event and event-detail page titles
- Remove placeholder comments and participant headings in events template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3e26afee483228d1db328f46f2fed