### PR TITLE
Fix participant ID sort query parameter

### DIFF
--- a/templates/participants.html
+++ b/templates/participants.html
@@ -19,7 +19,7 @@
                 <thead class="table-light">
                     <tr>
                         <th>
-                            <a href="?sort=pID&direction={% if sort == 'pid' and direction == 1 %}-1{% else %}1{% endif %}&search={{ search }}">
+                            <a href="?sort=pid&direction={% if sort == 'pid' and direction == 1 %}-1{% else %}1{% endif %}&search={{ search }}">
                                 ID {% if sort == 'pid' %}{% if direction == 1 %}↑{% else %}↓{% endif %}{% endif %}
                             </a>
                         </th>


### PR DESCRIPTION
## Summary
- Fix participant list ID column sort link to use lowercase `pid`

## Testing
- `pytest >/tmp/pytest.log; tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68c3e2670444832293eec78bec36d235