### PR TITLE
Show participant ID and link events from participant page

### DIFF
--- a/templates/participant_event.html
+++ b/templates/participant_event.html
@@ -1,8 +1,16 @@
 {% extends "base.html" %}
 
-{% block title %}Participants{% endblock %}
+{% block title %}Participant Details{% endblock %}
 
 {% block content %}
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      {% for message in messages %}
+        <div class="alert alert-info" role="alert">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
   <h1 class="mb-4">Participant Details</h1>
   <!-- your existing search, table, pagination -->
 
@@ -15,6 +23,7 @@
   ✏️ Edit Participant
 </a>
 </h2>
+    <p><strong>PID:</strong> {{ participant['pid'] }}</p>
     <p><strong>Position:</strong> {{ participant.position }}</p>
     <p><strong>Grade:</strong> {{ participant.grade }}</p>
     <p><strong>Country:</strong> {{ participant.country }}</p>
@@ -34,7 +43,7 @@
         {% for event in events %}
             <tr>
                 <td>{{ event.eid }}</td>
-                <td>{{ event.title }}</td>
+                <td><a href="{{ url_for('events.event_detail', eid=event.eid) }}">{{ event.title }}</a></td>
                 <td>{{ event.location }}</td>
                 <td>{{ event.dateFrom.strftime('%Y-%m-%d') if event.dateFrom else '' }}</td>
                 <td>{{ event.dateTo.strftime('%Y-%m-%d') if event.dateTo else '' }}</td>


### PR DESCRIPTION
## Summary
- Display flash messages and participant ID in participant details page
- Link each listed event to its details page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c3e268d7288322ae580f52a208c457