### PR TITLE
Refactor participant edit template for flash messages

### DIFF
--- a/templates/participant_edit.html
+++ b/templates/participant_edit.html
@@ -1,13 +1,13 @@
-{% with messages = get_flashed_messages() %}
-  {% if messages %}
-    <div class="alert alert-success">{{ messages[0] }}</div>
-  {% endif %}
-{% endwith %}
 {% extends "base.html" %}
 
 {% block title %}Participants{% endblock %}
 
 {% block content %}
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <div class="alert alert-success">{{ messages[0] }}</div>
+    {% endif %}
+  {% endwith %}
   <h1 class="mb-4">Participants</h1>
   <!-- your existing search, table, pagination -->
 <div class="container mt-4">
@@ -34,3 +34,4 @@
     </form>
 </div>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- Ensure participant edit template extends base.html from the first line
- Display flash messages within the content block for user feedback
- Maintain form fields for only name, position, and grade

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3e26a40a08322a3113ff5d139f4ab