### PR TITLE
Normalize participant phone numbers

### DIFF
--- a/services/participant_service.py
+++ b/services/participant_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import List, Optional, Dict, Any
 
 from domain.models.participant import Participant
@@ -9,6 +10,9 @@ from repositories.participant_repository import ParticipantRepository
 
 
 _repo = ParticipantRepository()
+
+
+DIGITS_RE = re.compile(r"\D")
 
 
 def list_participants() -> List[Participant]:
@@ -55,3 +59,11 @@ def update_participant(pid: str, updates: Dict[str, Any]) -> Optional[Participan
 def delete_participant(pid: str) -> bool:
     """Delete a participant by PID."""
     return _repo.delete(pid) > 0
+
+
+def normalize_phone(value: object) -> Optional[str]:
+    """Return phone number as ``+`` followed by digits or ``None`` if invalid."""
+    digits = DIGITS_RE.sub("", "" if value is None else str(value))
+    if 11 <= len(digits) <= 12:
+        return f"+{digits}"
+    return None

--- a/tests/test_phone_normalization.py
+++ b/tests/test_phone_normalization.py
@@ -1,0 +1,8 @@
+import services.participant_service as svc
+
+
+def test_normalize_phone():
+    assert svc.normalize_phone("+1 (202) 555-1234") == "+12025551234"
+    assert svc.normalize_phone("123") is None
+    assert svc.normalize_phone(None) is None
+

--- a/titan/normalize_participant_phones.py
+++ b/titan/normalize_participant_phones.py
@@ -1,0 +1,31 @@
+"""One-time script to normalize existing participant phone numbers.
+
+This script uses :func:`services.participant_service.normalize_phone` to ensure
+all stored phone numbers follow the canonical ``+`` followed by 11-12 digits
+format. Only documents with a ``phone`` field are processed and updated if a
+normalized value differs from the original.
+"""
+
+from __future__ import annotations
+
+from services.participant_service import normalize_phone
+from repositories.participant_repository import ParticipantRepository
+
+
+def main() -> None:
+    repo = ParticipantRepository()
+    for doc in repo.collection.find({"phone": {"$exists": True}}):
+        raw = doc.get("phone", "")
+        normalized = normalize_phone(raw)
+        if not normalized:
+            print(f"Skipping {doc.get('pid', doc.get('_id'))}: invalid phone '{raw}'")
+            continue
+        if normalized != raw:
+            repo.collection.update_one({"_id": doc["_id"]}, {"$set": {"phone": normalized}})
+            print(
+                f"Updated {doc.get('pid', doc.get('_id'))}: '{raw}' -> '{normalized}'"
+            )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution only
+    main()


### PR DESCRIPTION
## Summary
- expose `normalize_phone` utility for formatting individual phone numbers
- add one-off script to normalize existing participant phone numbers in MongoDB
- streamline tests to cover the normalization helper

## Testing
- `pytest tests/test_phone_normalization.py -q`
- `pytest -q` *(fails: Worksheet named 'Events' not found; assertion errors in import routes and name normalization tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c41a98ebbc83229f61dd2e2b61e4fe