### PR TITLE
Align participant model and import with extended schema

### DIFF
--- a/utils/initial_data.py
+++ b/utils/initial_data.py
@@ -12,43 +12,80 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import re
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Any
 
 import pandas as pd
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field, field_validator, ConfigDict
 
 from config.database import mongodb
-from domain.models.participant import Grade, Gender
+from domain.models.participant import Grade, Gender, Transport, DocType, IbanType
 
 class ParticipantRow(BaseModel):
     """Light-weight validation model for imported participants."""
 
+    model_config = ConfigDict(use_enum_values=True, populate_by_name=True)
+
     pid: str
     name: str
-    position: str
-    grade: Grade = Grade.NORMAL
     representing_country: str
     gender: Gender
-    dob: datetime
-    pob: str
-    birth_country: str
+
+    grade: Grade = Grade.NORMAL
+    position: str = ""
+    dob: Optional[datetime] = None
+    pob: str = ""
+    birth_country: str = ""
+    citizenships: Optional[list[str]] = None
+
     email: Optional[EmailStr] = None
-    phone: str
+    phone: Optional[str] = None
+
+    transportation: Optional[Transport] = None
+    transport_other: Optional[str] = None
+    travel_doc_type: Optional[DocType] = None
+    travel_doc_type_other: Optional[str] = None
+    travel_doc_issue_date: Optional[datetime] = None
+    travel_doc_expiry_date: Optional[datetime] = None
+    travel_doc_issued_by: Optional[str] = None
+
+    travelling_from: Optional[str] = None
+    returning_to: Optional[str] = None
+
+    diet_restrictions: Optional[str] = None
+    organization: Optional[str] = None
+    unit: Optional[str] = None
+    rank: Optional[str] = None
+    intl_authority: Optional[bool] = None
+    bio_short: Optional[str] = None
+
+    bank_name: Optional[str] = None
+    iban: Optional[str] = None
+    iban_type: Optional[IbanType] = None
+    swift: Optional[str] = None
+
+    created_at: datetime
+    updated_at: datetime
+    audit: list[dict[str, Any]] = Field(default_factory=list, alias="_audit")
+
+    @field_validator("email", "phone", mode="before")
+    @classmethod
+    def _blank_to_none(cls, value):
+        if value is None:
+            return None
+        if isinstance(value, float) and pd.isna(value):
+            return None
+        text = str(value).strip()
+        return text or None
 
     def to_mongo(self) -> dict:
-        data = self.model_dump()
-        # Store enum raw values for MongoDB
-        data["grade"] = data["grade"].value
-        data["gender"] = data["gender"].value
-        return data
+        return self.model_dump(by_alias=True, exclude_none=True)
 
 def as_dt_utc_midnight(v):
-    if pd.isna(v):
-        return datetime(1900, 1, 1, tzinfo=timezone.utc)   # or None if you prefer
+    if v is None or (isinstance(v, float) and pd.isna(v)):
+        return None
     ts = pd.to_datetime(v, errors="coerce")
     if pd.isna(ts):
-        return datetime(1900, 1, 1, tzinfo=timezone.utc)
-    # ts is a pandas.Timestamp → convert to python datetime and make tz-aware
+        return None
     dt = ts.to_pydatetime()
     return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
 
@@ -61,6 +98,42 @@ def as_utc_or_none(value):
         return None
     dt = ts.to_pydatetime()
     return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def _parse_enum(enum_cls, value):
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    for member in enum_cls:
+        if text.lower() in {member.value.lower(), member.name.lower()}:
+            return member
+    return None
+
+
+def _parse_bool(value) -> Optional[bool]:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    text = str(value).strip().lower()
+    if not text:
+        return None
+    if text in {"1", "true", "yes", "y"}:
+        return True
+    if text in {"0", "false", "no", "n"}:
+        return False
+    return None
+
+
+def _parse_citizenships(value) -> Optional[list[str]]:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    if isinstance(value, list):
+        items = [str(item).strip() for item in value if str(item).strip()]
+    else:
+        parts = re.split(r"[;,]", str(value))
+        items = [part.strip() for part in parts if part.strip()]
+    return items or None
 
 def _split_location(value: str) -> Tuple[str, Optional[str]]:
     """Split a raw location string into place and country hint components."""
@@ -87,6 +160,12 @@ def _split_location(value: str) -> Tuple[str, Optional[str]]:
             return place, country_hint or None
 
     return text, None
+
+
+def _clean_str(value: Any) -> str:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return ""
+    return str(value).strip()
 
 
 def check_and_import_data():
@@ -257,22 +336,57 @@ def check_and_import_data():
         def generate_pid(n: int) -> str:
             return f"P{n:04d}"
 
-        for _, row in df_participants.iterrows():
+        import_timestamp = datetime.now(timezone.utc)
+
+        for idx, row in df_participants.iterrows():
             raw_name = str(row.get("Name", "")).strip()
             if not raw_name:
                 continue
             name = normalize_name(raw_name)
-            position = str(row.get("Position", "")).strip()
-            country_name = str(row.get("Country", "")).strip()
-            gender_str = str(row.get("Gender", "")).strip().lower()
-            dob_val = pd.to_datetime(row.get("DOB"), errors="coerce")
-            pob = str(row.get("POB", "")).strip()
-            birth_country_name = str(row.get("Birth Country", "")).strip()
-            email = str(row.get("Email", "")).strip()
-            phone = str(row.get("Phone", "")).strip()
+            position = _clean_str(row.get("Position"))
+            country_name = _clean_str(row.get("Country"))
+            if not country_name:
+                print(f"Skipping participant without representing country: {name}")
+                continue
+            gender_str = _clean_str(row.get("Gender")).lower()
+            dob_val = row.get("DOB")
+            pob = _clean_str(row.get("POB"))
+            birth_country_name = _clean_str(row.get("Birth Country"))
+            email = _clean_str(row.get("Email"))
+            phone = _clean_str(row.get("Phone"))
             grade_val = row.get("Grade")
-            event_id = str(row.get("Event", "")).strip()
+            event_id = _clean_str(row.get("Event"))
             event_date = event_lookup.get(event_id, pd.Timestamp.min)
+
+            travel_doc_type = _parse_enum(DocType, row.get("Travel Document Type"))
+            travel_doc_type_other = _clean_str(row.get("Travel Document Type Other"))
+            travel_doc_issue_date = as_utc_or_none(row.get("Travel Document Issue Date"))
+            travel_doc_expiry_date = as_utc_or_none(row.get("Travel Document Expiry Date"))
+            travel_doc_issued_by = _clean_str(row.get("Travel Document Issued By"))
+
+            transportation = _parse_enum(
+                Transport,
+                row.get("Transportation")
+                if "Transportation" in row
+                else row.get("Transport"),
+            )
+            transport_other = _clean_str(row.get("Transportation Other"))
+            travelling_from = _clean_str(row.get("Travelling From"))
+            returning_to = _clean_str(row.get("Returning To"))
+
+            diet_restrictions = _clean_str(row.get("Diet Restrictions"))
+            organization = _clean_str(row.get("Organization"))
+            unit = _clean_str(row.get("Unit"))
+            rank = _clean_str(row.get("Rank"))
+            intl_authority = _parse_bool(row.get("Intl Authority"))
+            bio_short = _clean_str(row.get("Bio"))
+
+            bank_name = _clean_str(row.get("Bank Name"))
+            iban = _clean_str(row.get("IBAN"))
+            iban_type = _parse_enum(IbanType, row.get("IBAN Type"))
+            swift = _clean_str(row.get("SWIFT"))
+
+            citizenships = _parse_citizenships(row.get("Citizenships"))
 
             rep_cid = country_lookup.get(country_name.lower())
             if not rep_cid:
@@ -288,21 +402,25 @@ def check_and_import_data():
             birth_cid = birth_cid or rep_cid
 
             try:
-                gender = Gender(gender_str) if gender_str else Gender.male
+                gender = Gender(gender_str) if gender_str else None
             except ValueError:
-                gender = Gender.male
+                gender = None
+            if gender is None:
+                print(f"Skipping participant without valid gender: {name}")
+                continue
 
             try:
                 grade = Grade(int(grade_val)) if pd.notna(grade_val) else Grade.NORMAL
             except Exception:
                 grade = Grade.NORMAL
-            # before:
-            # dob = dob_val.date() if pd.notna(dob_val) else date(1900, 1, 1)
-
-            # after:
-            dob = as_dt_utc_midnight(dob_val)
 
             dedup_key = (name.lower(), rep_cid)
+
+            if not citizenships:
+                citizenships = [rep_cid]
+
+            pob_value = pob or ""
+            birth_country_value = birth_cid or rep_cid
 
             if dedup_key not in participant_data:
                 pid = generate_pid(participant_id_counter)
@@ -314,13 +432,34 @@ def check_and_import_data():
                     "grade": grade,
                     "representing_country": rep_cid,
                     "gender": gender,
-                    "dob": dob,
-                    "pob": pob,
-                    "birth_country": birth_cid,
+                    "dob": as_dt_utc_midnight(dob_val),
+                    "pob": pob_value,
+                    "birth_country": birth_country_value,
+                    "citizenships": citizenships,
                     "email": email,
                     "phone": phone,
                     "latest_date": event_date,
                     "events": [event_id],
+                    "transportation": transportation,
+                    "transport_other": transport_other,
+                    "travel_doc_type": travel_doc_type,
+                    "travel_doc_type_other": travel_doc_type_other,
+                    "travel_doc_issue_date": travel_doc_issue_date,
+                    "travel_doc_expiry_date": travel_doc_expiry_date,
+                    "travel_doc_issued_by": travel_doc_issued_by,
+                    "travelling_from": travelling_from,
+                    "returning_to": returning_to,
+                    "diet_restrictions": diet_restrictions,
+                    "organization": organization,
+                    "unit": unit,
+                    "rank": rank,
+                    "intl_authority": intl_authority,
+                    "bio_short": bio_short,
+                    "bank_name": bank_name,
+                    "iban": iban,
+                    "iban_type": iban_type,
+                    "swift": swift,
+                    "source": {"sheet": "Participant", "row": int(idx) + 2},
                 }
             else:
                 entry = participant_data[dedup_key]
@@ -329,25 +468,81 @@ def check_and_import_data():
                     entry["latest_date"] = event_date
                     entry["position"] = position
                     entry["grade"] = grade
+                    entry["transportation"] = transportation or entry.get("transportation")
+                    entry["transport_other"] = transport_other or entry.get("transport_other")
+                    entry["travel_doc_type"] = travel_doc_type or entry.get("travel_doc_type")
+                    entry["travel_doc_type_other"] = travel_doc_type_other or entry.get("travel_doc_type_other")
+                    entry["travel_doc_issue_date"] = travel_doc_issue_date or entry.get("travel_doc_issue_date")
+                    entry["travel_doc_expiry_date"] = travel_doc_expiry_date or entry.get("travel_doc_expiry_date")
+                    entry["travel_doc_issued_by"] = travel_doc_issued_by or entry.get("travel_doc_issued_by")
+                    entry["travelling_from"] = travelling_from or entry.get("travelling_from")
+                    entry["returning_to"] = returning_to or entry.get("returning_to")
+                    entry["diet_restrictions"] = diet_restrictions or entry.get("diet_restrictions")
+                    entry["organization"] = organization or entry.get("organization")
+                    entry["unit"] = unit or entry.get("unit")
+                    entry["rank"] = rank or entry.get("rank")
+                    entry["intl_authority"] = (intl_authority if intl_authority is not None else entry.get("intl_authority"))
+                    entry["bio_short"] = bio_short or entry.get("bio_short")
+                    entry["bank_name"] = bank_name or entry.get("bank_name")
+                    entry["iban"] = iban or entry.get("iban")
+                    entry["iban_type"] = iban_type or entry.get("iban_type")
+                    entry["swift"] = swift or entry.get("swift")
+
+                if not entry.get("citizenships") and citizenships:
+                    entry["citizenships"] = citizenships
 
         # === Insert Participants and Events ===
         event_participants: dict[str, set[str]] = {eid: set() for eid in event_docs}
 
         for pdata in participant_data.values():
             try:
-                participant_doc = ParticipantRow(**{
-                    "pid": pdata["pid"],
-                    "name": pdata["name"],
-                    "position": pdata["position"],
-                    "grade": pdata["grade"],
-                    "representing_country": pdata["representing_country"],
-                    "gender": pdata["gender"],
-                    "dob": pdata["dob"],
-                    "pob": pdata["pob"],
-                    "birth_country": pdata["birth_country"],
-                    "email": pdata["email"] or None,
-                    "phone": pdata["phone"],
-                }).to_mongo()
+                audit_entries = [
+                    {
+                        "ts": import_timestamp,
+                        "actor": "initial_import",
+                        "field": "grade",
+                        "from": None,
+                        "to": (pdata["grade"].value if isinstance(pdata["grade"], Grade) else pdata["grade"]),
+                        "source": pdata.get("source"),
+                    }
+                ]
+
+                participant_doc = ParticipantRow(
+                    pid=pdata["pid"],
+                    name=pdata["name"],
+                    representing_country=pdata["representing_country"],
+                    gender=pdata["gender"],
+                    grade=pdata["grade"],
+                    position=pdata.get("position", ""),
+                    dob=pdata.get("dob"),
+                    pob=pdata.get("pob", ""),
+                    birth_country=pdata.get("birth_country", ""),
+                    citizenships=pdata.get("citizenships"),
+                    email=pdata.get("email"),
+                    phone=pdata.get("phone"),
+                    transportation=pdata.get("transportation"),
+                    transport_other=pdata.get("transport_other"),
+                    travel_doc_type=pdata.get("travel_doc_type"),
+                    travel_doc_type_other=pdata.get("travel_doc_type_other"),
+                    travel_doc_issue_date=pdata.get("travel_doc_issue_date"),
+                    travel_doc_expiry_date=pdata.get("travel_doc_expiry_date"),
+                    travel_doc_issued_by=pdata.get("travel_doc_issued_by"),
+                    travelling_from=pdata.get("travelling_from"),
+                    returning_to=pdata.get("returning_to"),
+                    diet_restrictions=pdata.get("diet_restrictions"),
+                    organization=pdata.get("organization"),
+                    unit=pdata.get("unit"),
+                    rank=pdata.get("rank"),
+                    intl_authority=pdata.get("intl_authority"),
+                    bio_short=pdata.get("bio_short"),
+                    bank_name=pdata.get("bank_name"),
+                    iban=pdata.get("iban"),
+                    iban_type=pdata.get("iban_type"),
+                    swift=pdata.get("swift"),
+                    created_at=import_timestamp,
+                    updated_at=import_timestamp,
+                    audit=audit_entries,
+                ).to_mongo()
             except Exception as exc:
                 print(f"Skipping participant {pdata['pid']}: {exc}")
                 continue


### PR DESCRIPTION
## Summary
- relax the participant domain model so optional fields and audit metadata match the expanded document schema
- overhaul the initial data import to populate full participant records, including audit trail and timestamps, while defaulting grade to NORMAL when missing
- add parsing helpers for optional enum, boolean, date, and string fields so the generated documents follow the new structure

## Testing
- `pytest tests/test_participant_model.py` *(fails: email-validator dependency missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68efe54b44a483228f3139ea064e8106