### PR TITLE
Make import preview fields editable

### DIFF
--- a/templates/import_preview.html
+++ b/templates/import_preview.html
@@ -1,50 +1,91 @@
 {% extends "base.html" %}
 {% block title %}Import Preview{% endblock %}
 {% block content %}
-<h2>Event Preview</h2>
-{% if event %}
-  <dl class="row">
-    <dt class="col-sm-2">Event ID</dt>
-    <dd class="col-sm-10">{{ event.eid }}</dd>
-    <dt class="col-sm-2">Title</dt>
-    <dd class="col-sm-10">{{ event.title }}</dd>
-    <dt class="col-sm-2">Start</dt>
-    <dd class="col-sm-10">{{ event.start_date or '' }}</dd>
-    <dt class="col-sm-2">End</dt>
-    <dd class="col-sm-10">{{ event.end_date or '' }}</dd>
-    <dt class="col-sm-2">Place</dt>
-    <dd class="col-sm-10">{{ event.place }}</dd>
-    <dt class="col-sm-2">Country</dt>
-    <dd class="col-sm-10">{{ event.country }}</dd>
-    <dt class="col-sm-2">Type</dt>
-    <dd class="col-sm-10">{{ event.type or '' }}</dd>
-    <dt class="col-sm-2">Cost</dt>
-    <dd class="col-sm-10">{{ event.cost if event.cost is not none else '' }}</dd>
-  </dl>
-{% else %}
-  <p>No event data available.</p>
-{% endif %}
+  <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4">
+    <div>
+      <h1 class="h3 mb-1">Import preview</h1>
+      <p class="text-muted mb-0">Review and adjust all parsed fields before committing the upload.</p>
+    </div>
+    <a class="btn btn-outline-secondary mt-3 mt-md-0" href="{{ url_for('imports.upload_form') }}">Back</a>
+  </div>
 
-<h3>Participants ({{ participants|length }})</h3>
-<table class="table table-striped table-sm">
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Country</th>
-      <th>Grade</th>
-      <th>Position</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for p in participants %}
-    <tr>
-      <td>{{ p.name }}</td>
-      <td>{{ p.representing_country }}</td>
-      <td>{{ p.grade }}</td>
-      <td>{{ p.position }}</td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
-<a class="btn btn-secondary" href="{{ url_for('imports.upload_form') }}">Back</a>
+  <form>
+    <section class="mb-5">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="h4 mb-0">Event details</h2>
+        {% if event %}
+          <span class="badge text-bg-light">{{ event.get('eid', 'Draft event') }}</span>
+        {% endif %}
+      </div>
+
+      {% if event %}
+        <div class="row g-3">
+          {% for key, value in event|dictsort %}
+            {% set field_id = "event_" ~ key %}
+            <div class="col-md-6 col-lg-4">
+              <label class="form-label text-capitalize" for="{{ field_id }}">{{ key.replace('_', ' ') }}</label>
+              {% if value is mapping %}
+                <textarea class="form-control" id="{{ field_id }}" name="event[{{ key }}]" rows="3">{{ value|tojson(indent=2) }}</textarea>
+              {% elif value is sequence and value is not string %}
+                <textarea class="form-control" id="{{ field_id }}" name="event[{{ key }}]" rows="2">{{ value|join(', ') }}</textarea>
+              {% else %}
+                <input class="form-control" id="{{ field_id }}" name="event[{{ key }}]" type="text" value="{{ value if value is not none else '' }}">
+              {% endif %}
+            </div>
+          {% endfor %}
+        </div>
+      {% else %}
+        <div class="alert alert-warning" role="alert">No event data available.</div>
+      {% endif %}
+    </section>
+
+    <section>
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="h4 mb-0">Participants</h2>
+        <span class="badge text-bg-light">{{ participants|length }} total</span>
+      </div>
+
+      {% if participants %}
+        <div class="accordion" id="participantsAccordion">
+          {% for participant in participants %}
+            {% set participant_index = loop.index0 %}
+            {% set accordion_id = "participant_" ~ participant_index %}
+            <div class="accordion-item mb-2">
+              <h2 class="accordion-header" id="heading_{{ accordion_id }}">
+                <button class="accordion-button{% if not loop.first %} collapsed{% endif %}" type="button" data-bs-toggle="collapse" data-bs-target="#collapse_{{ accordion_id }}" aria-expanded="{{ 'true' if loop.first else 'false' }}" aria-controls="collapse_{{ accordion_id }}">
+                  {{ participant.get('name', 'Participant ' ~ loop.index) }}
+                </button>
+              </h2>
+              <div id="collapse_{{ accordion_id }}" class="accordion-collapse collapse{% if loop.first %} show{% endif %}" aria-labelledby="heading_{{ accordion_id }}" data-bs-parent="#participantsAccordion">
+                <div class="accordion-body">
+                  <div class="row g-3">
+                    {% for key, value in participant|dictsort %}
+                      {% set field_id = accordion_id ~ '_' ~ key %}
+                      <div class="col-md-6">
+                        <label class="form-label text-capitalize" for="{{ field_id }}">{{ key.replace('_', ' ') }}</label>
+                        {% if value is mapping %}
+                          <textarea class="form-control form-control-sm" id="{{ field_id }}" name="participants[{{ participant_index }}][{{ key }}]" rows="3">{{ value|tojson(indent=2) }}</textarea>
+                        {% elif value is sequence and value is not string %}
+                          <textarea class="form-control form-control-sm" id="{{ field_id }}" name="participants[{{ participant_index }}][{{ key }}]" rows="2">{{ value|join(', ') }}</textarea>
+                        {% else %}
+                          <input class="form-control form-control-sm" id="{{ field_id }}" name="participants[{{ participant_index }}][{{ key }}]" type="text" value="{{ value if value is not none else '' }}">
+                        {% endif %}
+                      </div>
+                    {% endfor %}
+                  </div>
+                </div>
+              </div>
+            </div>
+          {% endfor %}
+        </div>
+      {% else %}
+        <div class="alert alert-info" role="alert">No participants were found in the preview file.</div>
+      {% endif %}
+    </section>
+
+    <div class="mt-5 d-flex gap-3 justify-content-end">
+      <button class="btn btn-success" type="button">Upload NOW</button>
+      <button class="btn btn-outline-secondary" type="reset">Reset changes</button>
+    </div>
+  </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- render all event fields in the import preview as editable inputs
- present participant data in accordion sections with editable form controls
- add helper actions including a dummy “Upload NOW” button and reset option

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f116734fe88322be0435c51c6436d0