### PR TITLE
Simplify import enum handling for participant data

### DIFF
--- a/domain/models/participant.py
+++ b/domain/models/participant.py
@@ -24,15 +24,12 @@ class Gender(StrEnum):
 class Transport(StrEnum):
     pov = "Personal Vehicle (POV)"
     gov = "Government (Official) Vehicle (GOV)"
-    airplane = "Airplane"
+    air = "Air (Airplane)"
     other = "Other"
 
 
 class DocType(StrEnum):
     passport = "Passport"
-    id_card = "ID Card"
-    diplomatic_passport = "Diplomatic Passport"
-    service_passport = "Service Passport"
     other = "Other"
 
 

--- a/tests/test_participant_service_update.py
+++ b/tests/test_participant_service_update.py
@@ -93,7 +93,7 @@ def test_update_participant_from_form_updates_fields_and_audit(monkeypatch):
             "travel_doc_issued_by": "U.S. Department of State",
             "travel_doc_issue_date": "2020-01-01",
             "travel_doc_expiry_date": "2030-01-01",
-            "transportation": "Airplane",
+            "transportation": "Air (Airplane)",
             "transport_other": "",
             "travelling_from": "Washington, DC",
             "returning_to": "Zagreb, Croatia",
@@ -112,7 +112,7 @@ def test_update_participant_from_form_updates_fields_and_audit(monkeypatch):
     assert updated.representing_country == "US"
     assert updated.grade == Grade.EXCELLENT.value
     assert updated.birth_country == "US"
-    assert updated.transportation == Transport.airplane.value
+    assert updated.transportation == Transport.air.value
     assert updated.citizenships == ["HR", "US"]
     assert updated.audit, "audit history should not be empty"
     assert any(entry["field"] == "representing_country" for entry in updated.audit)


### PR DESCRIPTION
## Summary
- limit participant domain enums to the allowed Excel form values
- remove import-service enum normalization helpers and read trimmed strings directly
- store "Other" details for transportation and travel document types when present

## Testing
- pytest tests/test_participant_service_update.py

------
https://chatgpt.com/codex/tasks/task_e_68f23ad06b3483229d3bf55461f72e80