### PR TITLE
Update participant event repository to use EventParticipant model

### DIFF
--- a/domain/models/event_participant.py
+++ b/domain/models/event_participant.py
@@ -1,9 +1,11 @@
 # domain/models/event_participant.py (new)
+from __future__ import annotations
+
 from datetime import date
 from enum import StrEnum
 from typing import Optional
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 
 class Transport(StrEnum):
@@ -31,6 +33,8 @@ class IbanType(StrEnum):
     multi = "Multi-Currency"
 
 class EventParticipant(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+
     event_id: str
     participant_id: str
 
@@ -70,3 +74,14 @@ class EventParticipant(BaseModel):
         ):
             raise ValueError("travel_doc_issue_date must be on/before travel_doc_expiry_date.")
         return self
+
+    def to_mongo(self) -> dict:
+        """Serialize the event-participant snapshot for MongoDB."""
+        return self.model_dump(exclude_none=True)
+
+    @classmethod
+    def from_mongo(cls, doc: dict | None) -> "EventParticipant | None":
+        """Hydrate an EventParticipant from a MongoDB document."""
+        if not doc:
+            return None
+        return cls.model_validate(doc)

--- a/repositories/participant_event_repository.py
+++ b/repositories/participant_event_repository.py
@@ -41,6 +41,20 @@ class ParticipantEventRepository:
         )
         return str(result.upserted_id) if result.upserted_id else ""
 
+    def ensure_link(self, participant_id: str, event_id: str) -> None:
+        """Guarantee the existence of a link document without overwriting data."""
+
+        self.collection.update_one(
+            {"participant_id": participant_id, "event_id": event_id},
+            {
+                "$setOnInsert": {
+                    "participant_id": participant_id,
+                    "event_id": event_id,
+                }
+            },
+            upsert=True,
+        )
+
     def bulk_upsert(self, entries: Iterable[EventParticipant]) -> List[str]:
         """Insert or update several event participants."""
 

--- a/services/participant_event_service.py
+++ b/services/participant_event_service.py
@@ -44,6 +44,15 @@ def register_participant_event(data: Dict[str, Any]) -> None:
     if not payload.get("participant_id") or not payload.get("event_id"):
         raise ValueError("'participant_id' and 'event_id' are required")
 
+    canonical_keys = {k for k in payload.keys() if payload[k] is not None}
+    minimal_keys = {"participant_id", "event_id"}
+    if canonical_keys.issubset(minimal_keys):
+        _participant_event_repo.ensure_link(
+            participant_id=payload["participant_id"],
+            event_id=payload["event_id"],
+        )
+        return
+
     event_participant = EventParticipant(**payload)
     _participant_event_repo.upsert(event_participant)
 

--- a/tests/test_participant_event_repository.py
+++ b/tests/test_participant_event_repository.py
@@ -38,13 +38,15 @@ def test_participant_event_repository(monkeypatch):
                 None,
             )
             payload = dict(update.get("$set", {}))
+            insert_payload = dict(update.get("$setOnInsert", {}))
             if doc:
                 doc.update(payload)
                 class Res:
                     upserted_id = None
                 return Res()
             if kwargs.get("upsert"):
-                self.docs.append(payload)
+                new_doc = {**insert_payload, **payload}
+                self.docs.append(new_doc)
                 class Res:
                     upserted_id = "1"
                 return Res()
@@ -84,3 +86,6 @@ def test_participant_event_repository(monkeypatch):
 
     assert repo.list_for_event("E3")[0].participant_id == "P3"
     assert repo.list_for_participant("P3")[0].event_id == "E3"
+
+    repo.ensure_link("P4", "E4")
+    assert any(doc["participant_id"] == "P4" and doc["event_id"] == "E4" for doc in docs)

--- a/tests/test_participant_event_service.py
+++ b/tests/test_participant_event_service.py
@@ -9,6 +9,20 @@ from domain.models.event import Event
 from domain.models.test import TrainingTest, AttemptType
 
 
+def test_register_participant_event_minimal_payload(monkeypatch):
+    called = {}
+
+    class DummyPERepo:
+        def ensure_link(self, participant_id, event_id):
+            called["ensure_link"] = (participant_id, event_id)
+
+    monkeypatch.setattr(svc, "_participant_event_repo", DummyPERepo())
+
+    svc.register_participant_event({"pid": "P1", "eid": "E1"})
+
+    assert called["ensure_link"] == ("P1", "E1")
+
+
 def test_list_events_for_participant(monkeypatch):
     class DummyPERepo:
         def find_events(self, pid):
@@ -41,6 +55,7 @@ def test_event_participants_with_scores(monkeypatch):
     class DummyParticipant:
         def __init__(self, pid):
             self.pid = pid
+            self.participant_id = pid
 
         def model_dump(self):
             return {"pid": self.pid}


### PR DESCRIPTION
## Summary
- add serialization helpers to the new `EventParticipant` domain model
- refactor the participant-event repository and service to persist full event participant snapshots
- expand the participant-event repository test suite to exercise the new API

## Testing
- pytest tests/test_participant_event_repository.py

------
https://chatgpt.com/codex/tasks/task_e_68f25281246c832283b641f2105ae9c5