### PR TITLE
Update services for separated participant models

### DIFF
--- a/services/participant_service.py
+++ b/services/participant_service.py
@@ -7,14 +7,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 
-from domain.models.participant import (
-    DocType,
-    Gender,
-    Grade,
-    IbanType,
-    Participant,
-    Transport,
-)
+from domain.models.event_participant import DocType, IbanType, Transport
+from domain.models.participant import Gender, Grade, Participant
 from repositories.participant_repository import ParticipantRepository
 
 try:  # pragma: no cover - optional during limited test runs


### PR DESCRIPTION
## Summary
- update the participant service to consume enums from the new event participant domain model
- allow the events service to count attendees via the participant-event repository when available
- harden participant-event service helpers against missing repositories and datastore errors

## Testing
- pytest tests/test_participant_event_service.py

------
https://chatgpt.com/codex/tasks/task_e_68f258d598888322813b8b26a4f262d4