### PR TITLE
Update initial data seeding for split participant/event models

### DIFF
--- a/utils/initial_data.py
+++ b/utils/initial_data.py
@@ -17,12 +17,11 @@ from typing import Any, Optional, Tuple
 import pandas as pd
 
 from config.database import mongodb
-from domain.models.participant import (
+from domain.models.participant import Gender, Grade, Participant
+from domain.models.event_participant import (
     DocType,
-    Gender,
-    Grade,
+    EventParticipant,
     IbanType,
-    Participant,
     Transport,
 )
 
@@ -45,6 +44,11 @@ def as_utc_or_none(value):
         return None
     dt = ts.to_pydatetime()
     return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def as_date_or_none(value):
+    dt = as_utc_or_none(value)
+    return dt.date() if dt else None
 
 def _split_location(value: str) -> Tuple[str, Optional[str]]:
     """Split a raw location string into place and country hint components."""
@@ -156,6 +160,7 @@ def check_and_import_data():
     participants_col = db_conn['participants']
     events_col = db_conn['events']
     countries_col = db_conn['countries']
+    participant_events_col = db_conn['participant_events']
 
     # Check if data already exists FIRST
     event_count_db = events_col.count_documents({})
@@ -191,7 +196,7 @@ def check_and_import_data():
         participants_col.delete_many({})
         events_col.delete_many({})
         countries_col.delete_many({})
-        db_conn["participant_events"].delete_many({})
+        participant_events_col.delete_many({})
 
         # === Load Events and Index by ID ===
         now = datetime.now(timezone.utc)
@@ -332,9 +337,27 @@ def check_and_import_data():
         # === Deduplicate Participants Based on Normalized Name + Country ===
         participant_data: dict[tuple[str, str], dict[str, Any]] = {}
         participant_id_counter = 1
+        event_participant_rows: dict[tuple[str, str], dict[str, Any]] = {}
+        event_participant_sources: dict[tuple[str, str], dict[str, Any]] = {}
 
         def generate_pid(n: int) -> str:
             return f"P{n:04d}"
+
+        def _merge_event_participant(
+            existing: Optional[dict[str, Any]], new: dict[str, Any]
+        ) -> dict[str, Any]:
+            if existing is None:
+                return new
+            for key, value in new.items():
+                if key in {"participant_id", "event_id"}:
+                    existing[key] = value
+                    continue
+                if value is None:
+                    continue
+                if isinstance(value, str) and not value.strip():
+                    continue
+                existing[key] = value
+            return existing
 
         for row_index, row in df_participants.iterrows():
             row_number = int(row_index) + 2
@@ -388,19 +411,40 @@ def check_and_import_data():
 
             transportation = _normalize_transport(row.get("Transportation"))
             transport_other = _normalize_str(row.get("Transportation Other"))
+
             travelling_from = _normalize_str(row.get("Travelling From") or row.get("Traveling From"))
             returning_to = _normalize_str(row.get("Returning To"))
-            travel_doc_type = _normalize_doc_type(row.get("Travel Doc Type") or row.get("Travel Document Type"))
+            travelling_from_value = (
+                travelling_from or rep_country_raw or pob or "Unknown"
+            )
+            returning_to_value = (
+                returning_to or travelling_from_value or rep_country_raw or "Unknown"
+            )
+
+            travel_doc_type = _normalize_doc_type(
+                row.get("Travel Doc Type") or row.get("Travel Document Type")
+            )
             travel_doc_type_other = _normalize_str(row.get("Travel Doc Type Other"))
-            travel_doc_issue_date = as_utc_or_none(
+
+            travel_doc_issue_date = as_date_or_none(
                 row.get("Travel Doc Issue Date") or row.get("Travel Document Issue Date")
             )
-            travel_doc_expiry_date = as_utc_or_none(
+            travel_doc_expiry_date = as_date_or_none(
                 row.get("Travel Doc Expiry Date") or row.get("Travel Document Expiry Date")
             )
             travel_doc_issued_by = _normalize_str(
                 row.get("Travel Doc Issued By") or row.get("Travel Document Issued By")
+            ) or None
+
+            requires_visa_hr = _normalize_bool(
+                row.get("Requires Visa HR")
+                or row.get("Visa Required")
+                or row.get("Visa HR")
+                or row.get("Requires Visa")
+                or row.get("Do you require Visa to travel to Croatia")
             )
+            if requires_visa_hr is None:
+                requires_visa_hr = False
 
             citizenship_tokens = _split_multi_value(
                 row.get("Citizenships") or row.get("Citizenship")
@@ -436,29 +480,15 @@ def check_and_import_data():
                 "citizenships": citizenships,
                 "email": email or None,
                 "phone": phone or None,
-                "transportation": transportation,
-                "transport_other": transport_other or None,
-                "travel_doc_type": travel_doc_type,
-                "travel_doc_type_other": travel_doc_type_other or None,
-                "travel_doc_issue_date": travel_doc_issue_date,
-                "travel_doc_expiry_date": travel_doc_expiry_date,
-                "travel_doc_issued_by": travel_doc_issued_by or None,
-                "travelling_from": travelling_from or None,
-                "returning_to": returning_to or None,
                 "diet_restrictions": diet or None,
                 "organization": organization or None,
                 "unit": unit or None,
                 "rank": rank or None,
                 "intl_authority": intl_authority,
                 "bio_short": bio or None,
-                "bank_name": bank_name or None,
-                "iban": iban or None,
-                "iban_type": iban_type,
-                "swift": swift or None,
                 "created_at": now,
                 "updated_at": now,
                 "audit_source": audit_source,
-                "events": [event_id] if event_id else [],
                 "latest_date": event_date,
             }
 
@@ -469,8 +499,6 @@ def check_and_import_data():
                 participant_data[dedup_key] = participant_record
             else:
                 entry = participant_data[dedup_key]
-                if event_id:
-                    entry.setdefault("events", []).append(event_id)
                 for cid_value in participant_record.get("citizenships", []):
                     if cid_value and cid_value not in entry.get("citizenships", []):
                         entry.setdefault("citizenships", []).append(cid_value)
@@ -484,35 +512,48 @@ def check_and_import_data():
                         "birth_country": participant_record["birth_country"],
                         "email": participant_record["email"],
                         "phone": participant_record["phone"],
-                        "transportation": participant_record["transportation"],
-                        "transport_other": participant_record["transport_other"],
-                        "travel_doc_type": participant_record["travel_doc_type"],
-                        "travel_doc_type_other": participant_record["travel_doc_type_other"],
-                        "travel_doc_issue_date": participant_record["travel_doc_issue_date"],
-                        "travel_doc_expiry_date": participant_record["travel_doc_expiry_date"],
-                        "travel_doc_issued_by": participant_record["travel_doc_issued_by"],
-                        "travelling_from": participant_record["travelling_from"],
-                        "returning_to": participant_record["returning_to"],
                         "diet_restrictions": participant_record["diet_restrictions"],
                         "organization": participant_record["organization"],
                         "unit": participant_record["unit"],
                         "rank": participant_record["rank"],
                         "intl_authority": participant_record["intl_authority"],
                         "bio_short": participant_record["bio_short"],
-                        "bank_name": participant_record["bank_name"],
-                        "iban": participant_record["iban"],
-                        "iban_type": participant_record["iban_type"],
-                        "swift": participant_record["swift"],
                     })
                     entry["latest_date"] = event_date
                     entry["audit_source"] = audit_source
                 entry["updated_at"] = now
 
+            pid = participant_data[dedup_key]["pid"]
+
+            if event_id:
+                payload = {
+                    "event_id": event_id,
+                    "participant_id": pid,
+                    "transportation": transportation,
+                    "transport_other": transport_other or None,
+                    "requires_visa_hr": requires_visa_hr,
+                    "travelling_from": travelling_from_value,
+                    "returning_to": returning_to_value,
+                    "travel_doc_type": travel_doc_type,
+                    "travel_doc_type_other": travel_doc_type_other or None,
+                    "travel_doc_issue_date": travel_doc_issue_date,
+                    "travel_doc_expiry_date": travel_doc_expiry_date,
+                    "travel_doc_issued_by": travel_doc_issued_by,
+                    "bank_name": bank_name or None,
+                    "iban": iban or None,
+                    "iban_type": iban_type,
+                    "swift": swift or None,
+                }
+                key = (pid, event_id)
+                event_participant_rows[key] = _merge_event_participant(
+                    event_participant_rows.get(key), payload
+                )
+                event_participant_sources[key] = audit_source
+
         # === Insert Participants and Events ===
         event_participants: dict[str, set[str]] = {eid: set() for eid in event_docs}
 
         for pdata in participant_data.values():
-            events = list(set(filter(None, pdata.pop("events", []))))
             pdata.pop("latest_date", None)
             audit_source = pdata.pop("audit_source", {}) or {}
 
@@ -549,13 +590,52 @@ def check_and_import_data():
             participant_doc.setdefault("_audit", []).append(audit_entry)
             participants_col.insert_one(participant_doc)
 
-            for eid in events:
-                db_conn["participant_events"].insert_one({
-                    "participant_id": participant_doc["pid"],
-                    "event_id": eid,
-                })
-                if eid in event_participants:
-                    event_participants[eid].add(participant_doc["pid"])
+        for key, payload in event_participant_rows.items():
+            pid, eid = key
+            if not eid:
+                continue
+
+            event_payload = dict(payload)
+            event_payload["transportation"] = event_payload.get("transportation") or Transport.other
+            if (
+                event_payload["transportation"] == Transport.other
+                and not event_payload.get("transport_other")
+            ):
+                event_payload["transport_other"] = "Unspecified"
+
+            event_payload["travel_doc_type"] = (
+                event_payload.get("travel_doc_type") or DocType.passport
+            )
+            if (
+                event_payload["travel_doc_type"] == DocType.other
+                and not event_payload.get("travel_doc_type_other")
+            ):
+                event_payload["travel_doc_type_other"] = "Unspecified"
+
+            event_payload["travelling_from"] = (
+                event_payload.get("travelling_from") or "Unknown"
+            )
+            event_payload["returning_to"] = (
+                event_payload.get("returning_to")
+                or event_payload["travelling_from"]
+                or "Unknown"
+            )
+            event_payload["requires_visa_hr"] = bool(
+                event_payload.get("requires_visa_hr", False)
+            )
+
+            source_meta = event_participant_sources.get(key, {}) or {}
+
+            try:
+                event_participant = EventParticipant(**event_payload)
+            except Exception as exc:
+                raise ValueError(
+                    f"Row {source_meta.get('row', '?')}: unable to create event participant {pid}/{eid}: {exc}"
+                ) from exc
+
+            participant_events_col.insert_one(event_participant.to_mongo())
+            if eid in event_participants:
+                event_participants[eid].add(pid)
 
         print(f"✅ Import complete: {len(participant_data)} unique participants added.")
 


### PR DESCRIPTION
## Summary
- update the initial Excel import to use the new Participant and EventParticipant domain models
- create per-event participant records with EventParticipant and keep country lookups in sync with the new repositories
- ensure participant seeding no longer stores event-specific travel/banking data on the Participant document

## Testing
- pytest tests/test_import_name_variants.py *(fails: gender values differ in existing expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68f25d9f14d88322a8229a40e8598462