### PR TITLE
Implement import commit workflow

### DIFF
--- a/services/import_service.py
+++ b/services/import_service.py
@@ -1012,8 +1012,8 @@ def _hydrate_event_participant_payload(
         model = entry
     else:
         data = dict(entry or {})
-        if "eid" not in data and data.get("event_id"):
-            data["eid"] = data.pop("event_id")
+        if "event_id" not in data and data.get("eid"):
+            data["event_id"] = data.pop("eid")
         if "travelling_from" not in data and data.get("traveling_from"):
             data["travelling_from"] = data.pop("traveling_from")
 
@@ -1024,8 +1024,8 @@ def _hydrate_event_participant_payload(
 
         model = EventParticipant.model_validate(data)
 
-    if event_id and model.eid != event_id:
-        model = model.model_copy(update={"eid": event_id})
+    if event_id and model.event_id != event_id:
+        model = model.model_copy(update={"event_id": event_id})
 
     return model
 

--- a/templates/import_preview.html
+++ b/templates/import_preview.html
@@ -51,6 +51,27 @@
     ('Banking information', ['bank_name', 'iban', 'iban_type', 'swift'])
   ] %}
 
+  {% set event_field_groups = [
+    (
+      'Core details',
+      [
+        ('eid', 'Event ID'),
+        ('title', 'Title'),
+        ('type', 'Type'),
+        ('start_date', 'Start date'),
+        ('end_date', 'End date'),
+      ],
+    ),
+    (
+      'Location & logistics',
+      [
+        ('place', 'Place'),
+        ('country', 'Country'),
+        ('cost', 'Total cost'),
+      ],
+    ),
+  ] %}
+
   <form method="post" action="{{ url_for('imports.preview', preview_name=preview_name) }}">
     <section class="mb-5">
       <div class="d-flex justify-content-between align-items-center mb-3">
@@ -61,21 +82,60 @@
       </div>
 
       {% if event %}
-        <div class="row g-3">
-          {% for key, value in event|dictsort %}
-            {% set field_id = "event_" ~ key %}
-            <div class="col-md-6 col-lg-4">
-              <label class="form-label text-capitalize" for="{{ field_id }}">{{ key.replace('_', ' ') }}</label>
-              {% if value is mapping %}
-                <textarea class="form-control" id="{{ field_id }}" name="event[{{ key }}]" rows="3">{{ value|tojson(indent=2) }}</textarea>
-              {% elif value is sequence and value is not string %}
-                <textarea class="form-control" id="{{ field_id }}" name="event[{{ key }}]" rows="2">{{ value|join(', ') }}</textarea>
-              {% else %}
-                <input class="form-control" id="{{ field_id }}" name="event[{{ key }}]" type="text" value="{{ value if value is not none else '' }}">
-              {% endif %}
+        {% set rendered_event_keys = [] %}
+        {% for section_title, fields in event_field_groups %}
+          <div class="mb-4">
+            <h3 class="h6 text-uppercase text-muted mb-2">{{ section_title }}</h3>
+            <div class="row g-3">
+              {% for key, label in fields %}
+                {% set _ = rendered_event_keys.append(key) %}
+                {% set field_id = 'event_' ~ key %}
+                {% set value = event.get(key) %}
+                <div class="col-md-6 col-lg-4">
+                  <label class="form-label" for="{{ field_id }}">{{ label }}</label>
+                  {% if value is mapping %}
+                    <textarea class="form-control" id="{{ field_id }}" name="event[{{ key }}]" rows="3">{{ value|tojson(indent=2) }}</textarea>
+                  {% elif value is sequence and value is not string %}
+                    <textarea class="form-control" id="{{ field_id }}" name="event[{{ key }}]" rows="2">{{ value|join(', ') }}</textarea>
+                  {% elif key == 'cost' %}
+                    <input class="form-control" id="{{ field_id }}" name="event[{{ key }}]" type="number" step="0.01" inputmode="decimal" value="{{ value if value is not none else '' }}">
+                  {% else %}
+                    <input class="form-control" id="{{ field_id }}" name="event[{{ key }}]" type="text" value="{{ value if value is not none else '' }}">
+                  {% endif %}
+                </div>
+              {% endfor %}
             </div>
-          {% endfor %}
-        </div>
+          </div>
+        {% endfor %}
+
+        {% set additional_event_keys = [] %}
+        {% for key, value in event|dictsort %}
+          {% if key not in rendered_event_keys %}
+            {% set additional_event_keys = additional_event_keys + [key] %}
+          {% endif %}
+        {% endfor %}
+
+        {% if additional_event_keys %}
+          <div>
+            <h3 class="h6 text-uppercase text-muted mb-2">Additional details</h3>
+            <div class="row g-3">
+              {% for key in additional_event_keys %}
+                {% set field_id = 'event_' ~ key %}
+                {% set value = event.get(key) %}
+                <div class="col-md-6 col-lg-4">
+                  <label class="form-label" for="{{ field_id }}">{{ key.replace('_', ' ') }}</label>
+                  {% if value is mapping %}
+                    <textarea class="form-control" id="{{ field_id }}" name="event[{{ key }}]" rows="3">{{ value|tojson(indent=2) }}</textarea>
+                  {% elif value is sequence and value is not string %}
+                    <textarea class="form-control" id="{{ field_id }}" name="event[{{ key }}]" rows="2">{{ value|join(', ') }}</textarea>
+                  {% else %}
+                    <input class="form-control" id="{{ field_id }}" name="event[{{ key }}]" type="text" value="{{ value if value is not none else '' }}">
+                  {% endif %}
+                </div>
+              {% endfor %}
+            </div>
+          </div>
+        {% endif %}
       {% else %}
         <div class="alert alert-warning" role="alert">No event data available.</div>
       {% endif %}

--- a/tests/test_import_commit.py
+++ b/tests/test_import_commit.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from domain.models.event import Event
+from domain.models.event_participant import DocType, EventParticipant, Transport
+from domain.models.participant import Grade, Participant
+from services.import_service import commit_import
+
+
+class FakeEventRepository:
+    def __init__(self, existing: list[Event] | None = None) -> None:
+        self._events = {event.eid: event for event in (existing or [])}
+        self.saved_event: Event | None = None
+        self.ensure_indexes_called = 0
+
+    def ensure_indexes(self) -> None:
+        self.ensure_indexes_called += 1
+
+    def find_by_eid(self, eid: str) -> Event | None:
+        return self._events.get(eid)
+
+    def save(self, event: Event) -> str:
+        self.saved_event = event
+        self._events[event.eid] = event
+        return event.eid
+
+
+class FakeParticipantRepository:
+    def __init__(self, existing: list[Participant] | None = None) -> None:
+        self._participants = {p.pid: p for p in (existing or [])}
+        self.saved: list[Participant] = []
+        self.updated: list[tuple[str, dict]] = []
+        self.ensure_indexes_called = 0
+
+    def ensure_indexes(self) -> None:
+        self.ensure_indexes_called += 1
+
+    def find_by_pid(self, pid: str) -> Participant | None:
+        return self._participants.get(pid)
+
+    def save(self, participant: Participant) -> str:
+        self.saved.append(participant)
+        self._participants[participant.pid] = participant
+        return participant.pid
+
+    def update(self, pid: str, data: dict) -> Participant | None:
+        self.updated.append((pid, data))
+        existing = self._participants.get(pid)
+        if existing:
+            merged = existing.model_copy(update=data)
+        else:
+            merged = Participant.model_validate({"pid": pid, **data})
+        self._participants[pid] = merged
+        return merged
+
+
+class FakeParticipantEventRepository:
+    def __init__(self) -> None:
+        self.bulk_payloads: list[list[EventParticipant]] = []
+        self.ensure_indexes_called = 0
+
+    def ensure_indexes(self) -> None:
+        self.ensure_indexes_called += 1
+
+    def bulk_upsert(self, entries: list[EventParticipant]) -> list[str]:
+        self.bulk_payloads.append(list(entries))
+        return []
+
+
+def _participant_payload(**overrides) -> dict:
+    base = {
+        "representing_country": "HR",
+        "gender": "Male",
+        "grade": Grade.NORMAL.value,
+        "name": "John Doe",
+        "dob": datetime(1990, 5, 4),
+        "pob": "Zagreb",
+        "birth_country": "HR",
+        "citizenships": ["HR"],
+    }
+    base.update(overrides)
+    participant = Participant.model_validate(base)
+    return participant.model_dump(by_alias=True)
+
+
+def _event_participant_payload(pid: str, eid: str, **overrides) -> dict:
+    base = {
+        "eid": eid,
+        "participant_id": pid,
+        "transportation": Transport.air.value,
+        "travelling_from": "City A",
+        "returning_to": "City B",
+        "travel_doc_type": DocType.passport.value,
+    }
+    base.update(overrides)
+    snapshot = EventParticipant.model_validate(base)
+    return snapshot.model_dump(by_alias=True)
+
+
+def test_commit_import_aborts_when_event_exists():
+    existing_event = Event(eid="EVT-1", title="Existing Event")
+    payload = {"event": {"eid": "EVT-1", "title": "Existing Event", "place": "Zagreb"}}
+
+    event_repo = FakeEventRepository([existing_event])
+    participant_repo = FakeParticipantRepository()
+    participant_event_repo = FakeParticipantEventRepository()
+
+    with pytest.raises(RuntimeError) as excinfo:
+        commit_import(
+            payload,
+            event_repo=event_repo,
+            participant_repo=participant_repo,
+            participant_event_repo=participant_event_repo,
+        )
+
+    assert "Event (EVT-1" in str(excinfo.value)
+
+
+def test_commit_import_updates_and_creates_participants_and_links():
+    event_payload = {"eid": "EVT-42", "title": "Training", "place": "Zagreb"}
+
+    existing_participant = Participant.model_validate(
+        {
+            "pid": "P-001",
+            "representing_country": "HR",
+            "gender": "Male",
+            "grade": Grade.NORMAL.value,
+            "name": "Jane Existing",
+            "dob": datetime(1988, 7, 1),
+            "pob": "Split",
+            "birth_country": "HR",
+            "citizenships": ["HR"],
+            "phone": "+3851000000",
+        }
+    )
+
+    participant_repo = FakeParticipantRepository([existing_participant])
+    event_repo = FakeEventRepository()
+    participant_event_repo = FakeParticipantEventRepository()
+
+    updated_participant = existing_participant.model_copy(update={"phone": "+3852000000"})
+    updated_payload = updated_participant.model_dump(by_alias=True)
+
+    new_participant_payload = _participant_payload(pid="P-002", name="John New")
+
+    event_participant_existing = _event_participant_payload("P-001", "EVT-42")
+    event_participant_new = _event_participant_payload("P-002", "EVT-42")
+
+    payload = {
+        "event": event_payload,
+        "participants": [updated_payload, new_participant_payload],
+        "participant_events": [event_participant_existing, event_participant_new],
+    }
+
+    result = commit_import(
+        payload,
+        event_repo=event_repo,
+        participant_repo=participant_repo,
+        participant_event_repo=participant_event_repo,
+    )
+
+    assert event_repo.saved_event is not None
+    assert event_repo.saved_event.participants == ["P-001", "P-002"]
+
+    # Existing participant should be updated with the new phone number
+    assert participant_repo._participants["P-001"].phone == "+3852000000"
+    # New participant should be persisted
+    assert "P-002" in participant_repo._participants
+
+    # Participant-event snapshots should be forwarded for persistence
+    assert participant_event_repo.bulk_payloads
+    saved_snapshots = participant_event_repo.bulk_payloads[0]
+    assert {snap.participant_id for snap in saved_snapshots} == {"P-001", "P-002"}
+    assert all(snap.eid == "EVT-42" for snap in saved_snapshots)
+
+    # The result echoes hydrated models
+    assert len(result["participants"]) == 2
+    assert {p.pid for p in result["participants"]} == {"P-001", "P-002"}

--- a/tests/test_import_service_cost.py
+++ b/tests/test_import_service_cost.py
@@ -1,0 +1,45 @@
+import pytest
+from openpyxl import Workbook
+
+from services.import_service import _parse_cost_value, _read_event_header_block
+
+
+def test_parse_cost_value_handles_various_formats():
+    assert _parse_cost_value(12500) == pytest.approx(12500.0)
+    assert _parse_cost_value("12,345.67") == pytest.approx(12345.67)
+    assert _parse_cost_value("12.345,67") == pytest.approx(12345.67)
+    assert _parse_cost_value("EUR 9.876,54") == pytest.approx(9876.54)
+    assert _parse_cost_value(" ") is None
+    assert _parse_cost_value(None) is None
+    assert _parse_cost_value(True) is None
+
+
+def test_read_event_header_block_reads_cost_case_insensitive(tmp_path):
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "participants"
+    ws["A1"] = "PFE25M2 Example Event"
+    ws["A2"] = "JUNE 1 - 5 - City, COUNTRY"
+
+    cost_ws = wb.create_sheet("Cost overview")
+    cost_ws["B15"] = "123,456.78 EUR"
+
+    path = tmp_path / "preview.xlsx"
+    wb.save(path)
+
+    (
+        eid,
+        title,
+        start_date,
+        end_date,
+        place,
+        country,
+        cost,
+    ) = _read_event_header_block(str(path))
+
+    assert eid == "PFE25M2"
+    assert title == "Example Event"
+    assert start_date is not None
+    assert end_date is not None
+    assert place == "City"
+    assert cost == pytest.approx(123456.78)


### PR DESCRIPTION
## Summary
- add commit_import logic to hydrate parsed import payloads, guard against duplicate events, and persist participants and participant-event links
- introduce helpers to coerce enums and timestamps when instantiating domain models from preview data
- cover the new workflow with repository fakes exercising success and duplicate-event failure paths

## Testing
- pytest tests/test_import_commit.py

------
https://chatgpt.com/codex/tasks/task_e_68f7971e2a80832298858cb3d024556b