### PR TITLE
Extract serialization helpers into shared module

### DIFF
--- a/services/import_service_v2.py
+++ b/services/import_service_v2.py
@@ -69,11 +69,11 @@ from utils.normalize_phones import normalize_phone
 from utils.participants import _normalize_gender, lookup
 from utils.translation import translate
 from utils.serialization import (
-    _merge_attendee_preview,
-    _serialize_event_for_preview,
-    _serialize_model_for_preview,
-    _serialize_participant_event_for_preview,
-    _serialize_participant_for_preview,
+    merge_attendee_preview,
+    serialize_event,
+    serialize_model_for_preview,
+    serialize_participant_event,
+    serialize_participant,
 )
 
 # ==============================================================================
@@ -567,16 +567,16 @@ def parse_for_commit(path: str, *, preview_only: bool = True) -> dict:
             participant = participants_by_id.get(ep.participant_id)
             if not participant:
                 continue
-            attendees.append(_merge_attendee_preview(participant, ep))
+            attendees.append(merge_attendee_preview(participant, ep))
 
         payload = {
             "event": event_obj.model_dump() if event_obj else {},
             "attendees": attendees,
             "objects": custom_bundle,
             "preview": {
-                "event": _serialize_event_for_preview(event_obj),
-                "participants": [_serialize_participant_for_preview(p) for p in participants],
-                "participant_events": [_serialize_participant_event_for_preview(ep) for ep in participant_events],
+                "event": serialize_event(event_obj),
+                "participants": [serialize_participant(p) for p in participants],
+                "participant_events": [serialize_participant_event(ep) for ep in participant_events],
             },
         }
 

--- a/services/import_service_v2.py
+++ b/services/import_service_v2.py
@@ -68,6 +68,13 @@ from utils.names import (
 from utils.normalize_phones import normalize_phone
 from utils.participants import _normalize_gender, lookup
 from utils.translation import translate
+from utils.serialization import (
+    _merge_attendee_preview,
+    _serialize_event_for_preview,
+    _serialize_model_for_preview,
+    _serialize_participant_event_for_preview,
+    _serialize_participant_for_preview,
+)
 
 # ==============================================================================
 # 1. Configuration & Constants
@@ -329,114 +336,7 @@ def _build_participant_event_from_record(record: Dict[str, str]) -> Optional[Eve
 
 # ==============================================================================
 # 6. Serialization Helpers (Preview / Merging)  (REPLACED / OPTIMIZED)
-# ==============================================================================
-
-def _serialize_model_for_preview(obj, enum_fields: tuple = (), ensure_int_fields: tuple = ()):
-    """
-    Generic serializer for Pydantic models:
-      • Converts Enums → .value
-      • Keeps datetime fields as datetime (Mongo-compatible)
-      • Casts selected fields to int (e.g., grade)
-    """
-    if obj is None:
-        return {}
-
-    data = obj.model_dump(exclude_none=True)
-    out: Dict[str, Any] = {}
-
-    for key, val in data.items():
-        if key in enum_fields and hasattr(val, "value"):
-            out[key] = val.value
-        elif isinstance(val, datetime):
-            # keep native datetime (already EU tz)
-            out[key] = val
-        elif key in ensure_int_fields:
-            try:
-                out[key] = int(val)
-            except Exception:
-                out[key] = 1
-        else:
-            out[key] = val
-    return out
-
-
-def _serialize_event_for_preview(event: Optional[Event]) -> Dict[str, Any]:
-    """Serialize Event → dict with datetime kept for Mongo."""
-    return _serialize_model_for_preview(event, enum_fields=("type",))
-
-
-def _serialize_participant_for_preview(participant: Participant) -> Dict[str, Any]:
-    """Serialize Participant → dict with enums and datetimes preserved."""
-    return _serialize_model_for_preview(
-        participant,
-        enum_fields=("gender",),
-        ensure_int_fields=("grade",),
-    )
-
-
-def _serialize_participant_event_for_preview(ep: EventParticipant) -> Dict[str, Any]:
-    """Serialize EventParticipant → dict with enums and datetimes preserved."""
-    return _serialize_model_for_preview(
-        ep,
-        enum_fields=("transportation", "travel_doc_type", "iban_type"),
-    )
-
-
-def _merge_attendee_preview(participant: Participant, ep: EventParticipant) -> Dict[str, Any]:
-    """
-    Combine Participant and EventParticipant data into a single attendee preview record.
-    Keeps all datetime objects (Mongo-ready) and converts Enums to .value strings.
-    """
-    transportation = (
-        ep.transportation.value if hasattr(ep.transportation, "value") else ep.transportation
-    )
-    travel_doc_type = (
-        ep.travel_doc_type.value if hasattr(ep.travel_doc_type, "value") else ep.travel_doc_type
-    )
-    iban_type = (
-        ep.iban_type.value if hasattr(ep.iban_type, "value") else ep.iban_type
-    )
-
-    attendee: Dict[str, Any] = {
-        "pid": participant.pid,
-        "name": participant.name,
-        "representing_country": participant.representing_country,
-        "gender": participant.gender.value if hasattr(participant.gender, "value") else participant.gender,
-        "grade": int(participant.grade),
-        "dob": participant.dob,  # keep datetime
-        "pob": participant.pob,
-        "birth_country": participant.birth_country,
-        "citizenships": participant.citizenships or [],
-        "email": participant.email,
-        "phone": participant.phone,
-        "diet_restrictions": participant.diet_restrictions,
-        "organization": participant.organization,
-        "unit": participant.unit,
-        "position": participant.position,
-        "rank": participant.rank,
-        "intl_authority": participant.intl_authority,
-        "bio_short": participant.bio_short,
-        "event_id": ep.event_id,
-        "participant_id": ep.participant_id,
-        "transportation": transportation,
-        "transport_other": ep.transport_other,
-        "traveling_from": ep.traveling_from,
-        "returning_to": ep.returning_to,
-        "travel_doc_type": travel_doc_type,
-        "travel_doc_issue_date": ep.travel_doc_issue_date,  # keep datetime
-        "travel_doc_expiry_date": ep.travel_doc_expiry_date,  # keep datetime
-        "travel_doc_issued_by": ep.travel_doc_issued_by,
-        "bank_name": ep.bank_name,
-        "iban": ep.iban,
-        "iban_type": iban_type,
-        "swift": ep.swift,
-    }
-
-    return attendee
-
-
-# ==============================================================================
-# 7. XML Bundle Loader & Lookup Builders
+#     (Moved to utils.serialization)
 # ==============================================================================
 
 def _load_custom_xml_objects(path: str) -> Optional[Dict[str, Any]]:

--- a/utils/serialization.py
+++ b/utils/serialization.py
@@ -1,0 +1,117 @@
+"""
+Serialization helpers for converting Pydantic models to Mongo-friendly dictionaries.
+
+These helpers are intentionally unaware of Excel/tables/parsing logic.
+"""
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from domain.models.event import Event
+from domain.models.event_participant import EventParticipant
+from domain.models.participant import Participant
+
+
+def _serialize_model_for_preview(
+    obj, enum_fields: tuple = (), ensure_int_fields: tuple = ()
+):
+    """
+    Generic serializer for Pydantic models:
+      • Converts Enums → .value
+      • Keeps datetime fields as datetime (Mongo-compatible)
+      • Casts selected fields to int (e.g., grade)
+    """
+    if obj is None:
+        return {}
+
+    data = obj.model_dump(exclude_none=True)
+    out: Dict[str, Any] = {}
+
+    for key, val in data.items():
+        if key in enum_fields and hasattr(val, "value"):
+            out[key] = val.value
+        elif isinstance(val, datetime):
+            # keep native datetime (already EU tz)
+            out[key] = val
+        elif key in ensure_int_fields:
+            try:
+                out[key] = int(val)
+            except Exception:
+                out[key] = 1
+        else:
+            out[key] = val
+    return out
+
+
+def _serialize_event_for_preview(event: Optional[Event]) -> Dict[str, Any]:
+    """Serialize Event → dict with datetime kept for Mongo."""
+    return _serialize_model_for_preview(event, enum_fields=("type",))
+
+
+def _serialize_participant_for_preview(participant: Participant) -> Dict[str, Any]:
+    """Serialize Participant → dict with enums and datetimes preserved."""
+    return _serialize_model_for_preview(
+        participant,
+        enum_fields=("gender",),
+        ensure_int_fields=("grade",),
+    )
+
+
+def _serialize_participant_event_for_preview(ep: EventParticipant) -> Dict[str, Any]:
+    """Serialize EventParticipant → dict with enums and datetimes preserved."""
+    return _serialize_model_for_preview(
+        ep,
+        enum_fields=("transportation", "travel_doc_type", "iban_type"),
+    )
+
+
+def _merge_attendee_preview(participant: Participant, ep: EventParticipant) -> Dict[str, Any]:
+    """
+    Combine Participant and EventParticipant data into a single attendee preview record.
+    Keeps all datetime objects (Mongo-ready) and converts Enums to .value strings.
+    """
+    transportation = (
+        ep.transportation.value if hasattr(ep.transportation, "value") else ep.transportation
+    )
+    travel_doc_type = (
+        ep.travel_doc_type.value if hasattr(ep.travel_doc_type, "value") else ep.travel_doc_type
+    )
+    iban_type = (
+        ep.iban_type.value if hasattr(ep.iban_type, "value") else ep.iban_type
+    )
+
+    attendee: Dict[str, Any] = {
+        "pid": participant.pid,
+        "name": participant.name,
+        "representing_country": participant.representing_country,
+        "gender": participant.gender.value if hasattr(participant.gender, "value") else participant.gender,
+        "grade": int(participant.grade),
+        "dob": participant.dob,  # keep datetime
+        "pob": participant.pob,
+        "birth_country": participant.birth_country,
+        "citizenships": participant.citizenships or [],
+        "email": participant.email,
+        "phone": participant.phone,
+        "diet_restrictions": participant.diet_restrictions,
+        "organization": participant.organization,
+        "unit": participant.unit,
+        "position": participant.position,
+        "rank": participant.rank,
+        "intl_authority": participant.intl_authority,
+        "bio_short": participant.bio_short,
+        "event_id": ep.event_id,
+        "participant_id": ep.participant_id,
+        "transportation": transportation,
+        "transport_other": ep.transport_other,
+        "traveling_from": ep.traveling_from,
+        "returning_to": ep.returning_to,
+        "travel_doc_type": travel_doc_type,
+        "travel_doc_issue_date": ep.travel_doc_issue_date,  # keep datetime
+        "travel_doc_expiry_date": ep.travel_doc_expiry_date,  # keep datetime
+        "travel_doc_issued_by": ep.travel_doc_issued_by,
+        "bank_name": ep.bank_name,
+        "iban": ep.iban,
+        "iban_type": iban_type,
+        "swift": ep.swift,
+    }
+
+    return attendee

--- a/utils/serialization.py
+++ b/utils/serialization.py
@@ -11,7 +11,7 @@ from domain.models.event_participant import EventParticipant
 from domain.models.participant import Participant
 
 
-def _serialize_model_for_preview(
+def serialize_model_for_preview(
     obj, enum_fields: tuple = (), ensure_int_fields: tuple = ()
 ):
     """
@@ -42,29 +42,29 @@ def _serialize_model_for_preview(
     return out
 
 
-def _serialize_event_for_preview(event: Optional[Event]) -> Dict[str, Any]:
+def serialize_event(event: Optional[Event]) -> Dict[str, Any]:
     """Serialize Event → dict with datetime kept for Mongo."""
-    return _serialize_model_for_preview(event, enum_fields=("type",))
+    return serialize_model_for_preview(event, enum_fields=("type",))
 
 
-def _serialize_participant_for_preview(participant: Participant) -> Dict[str, Any]:
+def serialize_participant(participant: Participant) -> Dict[str, Any]:
     """Serialize Participant → dict with enums and datetimes preserved."""
-    return _serialize_model_for_preview(
+    return serialize_model_for_preview(
         participant,
         enum_fields=("gender",),
         ensure_int_fields=("grade",),
     )
 
 
-def _serialize_participant_event_for_preview(ep: EventParticipant) -> Dict[str, Any]:
+def serialize_participant_event(ep: EventParticipant) -> Dict[str, Any]:
     """Serialize EventParticipant → dict with enums and datetimes preserved."""
-    return _serialize_model_for_preview(
+    return serialize_model_for_preview(
         ep,
         enum_fields=("transportation", "travel_doc_type", "iban_type"),
     )
 
 
-def _merge_attendee_preview(participant: Participant, ep: EventParticipant) -> Dict[str, Any]:
+def merge_attendee_preview(participant: Participant, ep: EventParticipant) -> Dict[str, Any]:
     """
     Combine Participant and EventParticipant data into a single attendee preview record.
     Keeps all datetime objects (Mongo-ready) and converts Enums to .value strings.


### PR DESCRIPTION
## Summary
- move serialization helper functions into a new utils/serialization.py module
- update import_service_v2 to import shared helpers instead of local definitions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed3b34c508322a9ef22494b948f31)