### PR TITLE
Refactor import service utilities

### DIFF
--- a/services/import_service_v2.py
+++ b/services/import_service_v2.py
@@ -49,7 +49,6 @@ from config.settings import DEBUG_PRINT, REQUIRE_PARTICIPANTS_LIST
 from domain.models.event import Event, EventType
 from domain.models.event_participant import DocType, EventParticipant
 from domain.models.participant import Grade, Participant
-from repositories.participant_repository import ParticipantRepository
 from services.xlsx_tables_inspector import list_tables, TableRef
 from utils.country_resolver import COUNTRY_TABLE_MAP, resolve_country_flexible, get_country_cid_by_name, \
     _split_multi_country
@@ -74,7 +73,7 @@ from utils.names import (
     _to_app_display_name,
 )
 from utils.normalize_phones import normalize_phone
-from utils.participants import _normalize_gender, initialize_cache, lookup
+from utils.participants import _normalize_gender, lookup
 from utils.translation import translate
 from utils.serialization import (
     merge_attendee_preview,
@@ -88,14 +87,7 @@ from utils.serialization import (
 # 1. Configuration & Constants
 # ==============================================================================
 
-try:  # pragma: no cover - exercised indirectly via repo lookups
-    _participant_repo: Optional[ParticipantRepository] = ParticipantRepository()
-except Exception:  # pragma: no cover - allow parsing when DB is unavailable
-    _participant_repo = None  # type: ignore
-
-# Keep participant lookups and caching behavior consistent with the legacy import
-# flow by initializing the shared cache with the repository on module import.
-initialize_cache(_participant_repo)
+_participant_repo: Optional[Any] = None
 
 # ==============================================================================
 # 4. Data Coercion and Normalization Helpers  (REPLACED / OPTIMIZED)

--- a/services/import_service_v2.py
+++ b/services/import_service_v2.py
@@ -74,7 +74,7 @@ from utils.names import (
     _to_app_display_name,
 )
 from utils.normalize_phones import normalize_phone
-from utils.participants import _normalize_gender, lookup
+from utils.participants import _normalize_gender, initialize_cache, lookup
 from utils.translation import translate
 from utils.serialization import (
     merge_attendee_preview,
@@ -92,6 +92,10 @@ try:  # pragma: no cover - exercised indirectly via repo lookups
     _participant_repo: Optional[ParticipantRepository] = ParticipantRepository()
 except Exception:  # pragma: no cover - allow parsing when DB is unavailable
     _participant_repo = None  # type: ignore
+
+# Keep participant lookups and caching behavior consistent with the legacy import
+# flow by initializing the shared cache with the repository on module import.
+initialize_cache(_participant_repo)
 
 # ==============================================================================
 # 4. Data Coercion and Normalization Helpers  (REPLACED / OPTIMIZED)

--- a/utils/builders.py
+++ b/utils/builders.py
@@ -1,0 +1,105 @@
+from typing import Any, Dict, List, Optional
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from config.settings import DEBUG_PRINT
+from domain.models.event import Event, EventType
+from domain.models.event_participant import EventParticipant
+from domain.models.participant import Participant
+from utils.dates import coerce_datetime, normalize_dob
+from utils.helpers import _parse_bool_value
+from utils.normalization import normalize_gender
+from utils.participants import _coerce_grade_value
+
+EU_TZ = ZoneInfo("Europe/Zagreb")  # Used for all datetime coercion
+
+
+def _coerce_event_type(value: object) -> Optional[EventType]:
+    """Coerce a raw value to ``EventType`` when possible."""
+
+    if value is None:
+        return None
+    if isinstance(value, EventType):
+        return value
+    s = str(value).strip()
+    if not s:
+        return None
+    for variant in (s, s.title(), s.upper()):
+        try:
+            return EventType(variant)
+        except ValueError:
+            continue
+    return None
+
+
+def _build_event_from_record(record: Dict[str, str]) -> Event:
+    """Build an ``Event`` model instance from a raw record dictionary."""
+
+    start_date = coerce_datetime(record.get("start_date"), tzinfo=EU_TZ)
+    end_date = coerce_datetime(record.get("end_date"), tzinfo=EU_TZ)
+
+    cost_val: Optional[float] = None
+    cost_raw = record.get("cost")
+    if cost_raw not in (None, ""):
+        try:
+            cost_val = float(str(cost_raw).strip())
+        except ValueError:
+            cost_val = None
+
+    event_type = _coerce_event_type(record.get("type"))
+
+    return Event(
+        eid=str(record.get("eid", "")),
+        title=str(record.get("title", "")),
+        start_date=start_date,
+        end_date=end_date,
+        place=str(record.get("place", "")),
+        country=record.get("country") or None,
+        type=event_type,
+        cost=cost_val,
+    )
+
+
+def _build_participant_from_record(record: Dict[str, str]) -> Optional[Participant]:
+    """Build a ``Participant`` model instance from a raw record dictionary."""
+
+    data: Dict[str, Any] = dict(record)
+
+    normalized_gender = normalize_gender(data.get("gender"))
+    if normalized_gender is not None:
+        data["gender"] = normalized_gender
+
+    data["grade"] = _coerce_grade_value(data.get("grade"))
+    dob_dt = normalize_dob(data.get("dob"))
+    if dob_dt:
+        data["dob"] = dob_dt
+
+    for field in ["intl_authority"]:
+        if field in data:
+            val = _parse_bool_value(data[field])
+            if val is not None:
+                data[field] = val
+
+    try:
+        return Participant.model_validate(data)
+    except Exception as exc:
+        if DEBUG_PRINT:
+            print(f"[CUSTOM-XML] Failed to build Participant: {exc}")
+        return None
+
+
+def _build_participant_event_from_record(record: Dict[str, str]) -> Optional[EventParticipant]:
+    """Build an ``EventParticipant`` instance from a raw record dictionary."""
+
+    data: Dict[str, Any] = dict(record)
+    for key in ("travel_doc_issue_date", "travel_doc_expiry_date"):
+        if key in data:
+            data[key] = coerce_datetime(data.get(key), tzinfo=EU_TZ)
+
+    try:
+        return EventParticipant.model_validate(data)
+    except Exception as exc:
+        if DEBUG_PRINT:
+            print(f"[CUSTOM-XML] Failed to build EventParticipant: {exc}")
+        return None

--- a/utils/custom_xml.py
+++ b/utils/custom_xml.py
@@ -1,0 +1,80 @@
+import xml.etree.ElementTree as ET
+import zipfile
+from typing import Dict, List, Optional
+
+from config.settings import DEBUG_PRINT
+
+
+def _strip_xml_tag(tag: str) -> str:
+    """Remove namespace from an XML tag."""
+
+    return tag.split("}", 1)[1] if "}" in tag else tag
+
+
+def _element_to_flat_dict(elem: ET.Element, prefix: str = "") -> Dict[str, str]:
+    """Recursively flatten an XML element into a key-value dict."""
+
+    children = list(elem)
+    if not children:
+        key = prefix or _strip_xml_tag(elem.tag)
+        return {key: (elem.text or "").strip()}
+
+    data: Dict[str, str] = {}
+    for child in children:
+        child_tag = _strip_xml_tag(child.tag)
+        child_prefix = f"{prefix}_{child_tag}" if prefix else child_tag
+        child_data = _element_to_flat_dict(child, child_prefix)
+        for key, value in child_data.items():
+            if not value:
+                continue
+            if key in data and data[key]:
+                data[key] = f"{data[key]}; {value}"
+            else:
+                data[key] = value
+    return data
+
+
+def _collect_custom_xml_records(path: str) -> Optional[Dict[str, List[Dict[str, str]]]]:
+    """Collect embedded CustomXML parts from an Excel .xlsx file."""
+
+    try:
+        with zipfile.ZipFile(path) as zf:
+            names = [
+                n for n in zf.namelist()
+                if n.startswith("customXml/") and n.endswith(".xml")
+            ]
+            if not names:
+                return None
+
+            collected = {
+                "participant": [],
+                "event": [],
+                "participant_event": [],
+            }
+
+            for name in names:
+                try:
+                    root = ET.fromstring(zf.read(name))
+                except ET.ParseError:
+                    if DEBUG_PRINT:
+                        print(f"[CUSTOM-XML] Failed to parse {name}")
+                    continue
+
+                stack = [root]
+                while stack:
+                    node = stack.pop()
+                    tag = _strip_xml_tag(node.tag)
+                    if tag in collected:
+                        collected[tag].append(_element_to_flat_dict(node))
+                    stack.extend(list(node))
+
+            if not any(collected.values()):
+                return None
+
+            return {
+                "participants": collected["participant"],
+                "events": collected["event"],
+                "participant_events": collected["participant_event"],
+            }
+    except (zipfile.BadZipFile, FileNotFoundError):
+        return None

--- a/utils/events.py
+++ b/utils/events.py
@@ -1,0 +1,9 @@
+import re
+from datetime import UTC, datetime
+
+
+def _filename_year_from_eid(filename: str) -> int:
+    """Infer the event year from an EID prefix (e.g. PFE25 → 2025)."""
+
+    m = re.search(r"(\d{2})", filename)
+    return 2000 + int(m.group(1)) if m else datetime.now(UTC).year

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,0 +1,47 @@
+from typing import Optional
+
+from utils.normalize_phones import normalize_phone
+from utils.normalization import (
+    as_str_or_empty,
+    normalize_string,
+    parse_bool_value,
+)
+
+
+def _normalize(s: Optional[str]) -> str:
+    """Normalize whitespace and coerce None to an empty string."""
+
+    return normalize_string(s)
+
+
+def _as_str_or_empty(obj: object) -> str:
+    """Fast, null-safe conversion to stripped string."""
+
+    return as_str_or_empty(obj)
+
+
+def _parse_bool_value(value: object):
+    """Accept only True/False or case-insensitive Yes/No."""
+
+    return parse_bool_value(value)
+
+
+def _fill_if_missing(dst: dict, key: str, src: dict, src_key: Optional[str] = None) -> None:
+    """If ``dst[key]`` is empty, copy ``src[src_key or key]`` if truthy."""
+
+    k = src_key or key
+    if dst.get(key):
+        return
+
+    value = src.get(k)
+    if not value:
+        return
+
+    if key == "phone":
+        normalized = normalize_phone(value)
+        if not normalized:
+            return
+        dst[key] = normalized
+        return
+
+    dst[key] = value

--- a/utils/lookup.py
+++ b/utils/lookup.py
@@ -1,0 +1,131 @@
+import re
+from typing import Dict, Optional
+
+import pandas as pd
+
+from utils.helpers import _normalize
+from utils.names import _name_key, _name_key_from_raw, _to_app_display_name
+from utils.normalize_phones import normalize_phone
+from utils.normalization import normalize_gender, normalize_doc_type_label
+from utils.translation import translate
+
+
+def _build_lookup_participantslista(df_positions: pd.DataFrame) -> Dict[str, Dict[str, str]]:
+    """Build lookup from the ``ParticipantsLista`` sheet."""
+
+    name_col = next((c for c in df_positions.columns if "name (" in c.lower()), None)
+    pos_col = next((c for c in df_positions.columns if "position" in c.lower()), None)
+    phone_col = next((c for c in df_positions.columns if "phone" in c.lower()), None)
+    email_col = next((c for c in df_positions.columns if "email" in c.lower()), None)
+
+    look: Dict[str, Dict[str, str]] = {}
+    if not name_col:
+        return look
+
+    for _, row in df_positions.iterrows():
+        raw = _normalize(str(row.get(name_col, "")))
+        key = _name_key_from_raw(raw)
+        if not key:
+            continue
+        phone_value = normalize_phone(row.get(phone_col, "")) if phone_col else None
+        look[key] = {
+            "position": _normalize(str(row.get(pos_col, ""))) if pos_col else "",
+            "phone": phone_value or "",
+            "email": _normalize(str(row.get(email_col, ""))) if email_col else "",
+        }
+    return look
+
+
+def _build_lookup_main_online(df_online: pd.DataFrame) -> Dict[str, Dict[str, object]]:
+    """Build lookup from the ``MAIN ONLINE → ParticipantsList`` table."""
+
+    cols = {c.lower().strip(): c for c in df_online.columns}
+
+    def col(label: str) -> Optional[str]:
+        return cols.get(label.lower())
+
+    look: Dict[str, Dict[str, object]] = {}
+    for _, row in df_online.iterrows():
+        first = _normalize(str(row.get(col("Name")) or ""))
+        middle = _normalize(str(row.get(col("Middle name")) or ""))
+        last = _normalize(str(row.get(col("Last name")) or ""))
+
+        if not first and not last:
+            continue
+
+        first_middle = " ".join(part for part in [first, middle] if part).strip()
+        key = _name_key(last, first_middle)
+        keys = [key]
+        if middle and first:
+            keys.append(_name_key(last, first))  # Fallback
+
+        gender_col = col("Gender")
+        gender_raw = (str(row.get(gender_col, "")) if gender_col else "").strip()
+        normalized_gender = normalize_gender(gender_raw)
+        gender = normalized_gender.value if normalized_gender else gender_raw
+
+        birth_country_raw = re.sub(
+            r",\s*world$", "", _normalize(str(row.get(col("Country of Birth"), ""))), flags=re.IGNORECASE
+        )
+
+        travel_doc_type_col = col("Traveling document type")
+        travel_doc_type_raw = (
+            str(row.get(travel_doc_type_col, "")) if travel_doc_type_col else ""
+        ).strip()
+        travel_doc_type_value = normalize_doc_type_label(travel_doc_type_raw)
+
+        transportation_col = col("Transportation")
+        transport_other_col = col("Transportation (Other)")
+        iban_type_col = col("IBAN Type")
+
+        transportation_value = str(row.get(transportation_col, "")) if transportation_col else ""
+        transport_other_value = str(row.get(transport_other_col, "")) if transport_other_col else ""
+        iban_type_value = str(row.get(iban_type_col, "")) if iban_type_col else ""
+
+        phone_col = col("Phone number")
+        phone_raw = row.get(phone_col, "") if phone_col else ""
+        phone_list_value = normalize_phone(phone_raw) or ""
+
+        entry = {
+            "name": _to_app_display_name(" ".join([first, middle, last]).strip()),
+            "gender": gender,
+            "dob": row.get(col("Date of Birth (DOB)")),
+            "pob": _normalize(str(row.get(col("Place Of Birth (POB)"), ""))),
+            "birth_country": birth_country_raw,
+            "citizenships": [
+                _normalize(x)
+                for x in re.split(r"[;,]", str(row.get(col("Citizenship(s)"), "")))
+                if _normalize(x)
+            ],
+            "email_list": _normalize(str(row.get(col("Email address"), ""))),
+            "phone_list": phone_list_value,
+            "travel_doc_type": travel_doc_type_value,
+            "travel_doc_number": _normalize(str(row.get(col("Traveling document number"), ""))),
+            "travel_doc_issue": row.get(col("Traveling document issuance date")),
+            "travel_doc_expiry": row.get(col("Traveling document expiration date")),
+            "travel_doc_issued_by": translate(
+                _normalize(str(row.get(col("Traveling document issued by"), ""))), "en"
+            ),
+            "transportation_declared": transportation_value.strip(),
+            "transport_other": transport_other_value.strip(),
+            "traveling_from_declared": _normalize(str(row.get(col("Traveling from"), ""))),
+            "returning_to": _normalize(str(row.get(col("Returning to"), ""))),
+            "diet_restrictions": _normalize(str(row.get(col("Diet restrictions"), ""))),
+            "organization": translate(_normalize(str(row.get(col("Organization"), ""))), "en"),
+            "unit": translate(_normalize(str(row.get(col("Unit"), ""))), "en"),
+            "rank": translate(_normalize(str(row.get(col("Rank"), ""))), "en"),
+            "intl_authority": _normalize(str(row.get(col("Authority"), ""))),
+            "bio_short": translate(_normalize(str(row.get(col("Short professional biography"), ""))), "en"),
+            "bank_name": _normalize(str(row.get(col("Bank name"), ""))),
+            "iban": _normalize(str(row.get(col("IBAN"), ""))),
+            "iban_type": iban_type_value.strip(),
+            "swift": _normalize(str(row.get(col("SWIFT"), ""))),
+        }
+
+        for nk in keys:
+            if not nk:
+                continue
+            if nk not in look:
+                look[nk] = entry
+
+    return look

--- a/utils/normalization.py
+++ b/utils/normalization.py
@@ -1,0 +1,66 @@
+import re
+from typing import Optional
+
+import pandas as pd
+
+from domain.models.event_participant import DocType
+from domain.models.participant import Gender
+
+_BOOL_MAP = {
+    "yes": True,
+    "no": False,
+    "true": True,
+    "false": False,
+}
+
+
+def normalize_string(value: Optional[str]) -> str:
+    """Normalize whitespace and coerce ``None`` to an empty string."""
+
+    return re.sub(r"\s+", " ", (value or "").strip())
+
+
+def as_str_or_empty(obj: object) -> str:
+    """Fast, null-safe conversion to stripped string."""
+
+    return str(obj).strip() if obj is not None else ""
+
+
+def parse_bool_value(value: object) -> Optional[bool]:
+    """Accept boolean-like inputs; otherwise return ``None``."""
+
+    if isinstance(value, bool):
+        return value
+    s = as_str_or_empty(value).lower()
+    return _BOOL_MAP.get(s)
+
+
+def normalize_gender(value) -> Optional[Gender]:
+    """Normalize diverse gender labels into the ``Gender`` enum."""
+
+    if isinstance(value, Gender):
+        return value
+    if value is None:
+        return None
+    if isinstance(value, float) and pd.isna(value):
+        return None
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    normalized = text.lower().rstrip(".")
+    if normalized in {"m", "male", "man", "mr"}:
+        return Gender.male
+    if normalized in {"f", "female", "woman", "ms", "mrs"}:
+        return Gender.female
+
+    return None
+
+
+def normalize_doc_type_label(value: object) -> str:
+    """Return 'Passport' only if value == 'Passport'; otherwise 'ID Card'."""
+
+    if value == "Passport":
+        return str(DocType.passport.value)
+    return str(DocType.id_card.value)


### PR DESCRIPTION
## Summary
- move import_service_v2 helper logic into focused utility modules for builders, lookups, normalization, and custom XML parsing
- update import_service_v2 orchestration to use shared helpers and keep preview date handling consistent

## Testing
- pytest tests/test_import_custom_xml.py tests/test_import_existing_participant_pid.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f151b9da08322af78c5ae9705f047)