### PR TITLE
Add bulk DOCX upload and participant extraction workflow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ python-dateutil==2.9.0.post0
 tzdata==2025.2
 requests
 
+
+python-docx==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ requests
 
 
 python-docx==1.1.2
+openai==1.66.3

--- a/routes/docx_upload.py
+++ b/routes/docx_upload.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+
+from flask import Blueprint, current_app, flash, redirect, render_template, request, url_for
+from werkzeug.utils import secure_filename
+
+from middleware.auth import login_required
+from services.docx_import_service import DocxImportService
+
+
+docx_upload_bp = Blueprint("docx_upload", __name__, url_prefix="/upload/docx")
+
+
+@docx_upload_bp.route("", methods=["GET", "POST"], strict_slashes=False)
+@login_required
+def upload_docx():
+    if request.method == "GET":
+        return render_template("docx_review.html", participants=[], stage="upload")
+
+    eid = (request.form.get("eid") or "").strip()
+    files = request.files.getlist("files")
+    if not eid:
+        flash("Missing event id (eid).", "danger")
+        return redirect(url_for("docx_upload.upload_docx"))
+
+    if not files:
+        flash("Please choose at least one DOCX file.", "warning")
+        return redirect(url_for("docx_upload.upload_docx"))
+
+    upload_root = current_app.config.get("UPLOADS_DIR", os.path.join(os.getcwd(), "uploads"))
+    upload_dir = os.path.join(upload_root, "docx")
+    os.makedirs(upload_dir, exist_ok=True)
+
+    saved_files: list[str] = []
+    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    for file in files:
+        if not file.filename:
+            continue
+        filename = secure_filename(file.filename)
+        if not filename.lower().endswith(".docx"):
+            continue
+        full_name = f"{timestamp}_{filename}"
+        path = os.path.join(upload_dir, full_name)
+        file.save(path)
+        saved_files.append(path)
+
+    if not saved_files:
+        flash("No valid .docx files were provided.", "danger")
+        return redirect(url_for("docx_upload.upload_docx"))
+
+    service = DocxImportService()
+    bundle = service.extract_participants(saved_files, eid)
+
+    return render_template(
+        "docx_review.html",
+        participants=bundle["participants"],
+        eid=eid,
+        stage="review",
+    )
+
+
+@docx_upload_bp.post("/compare")
+@login_required
+def compare_docx():
+    service = DocxImportService()
+    eid = request.form.get("eid", "")
+    participants_blob = request.form.get("participants_json", "[]")
+    participants = json.loads(participants_blob)
+
+    compared = []
+    for participant in participants:
+        result = service.compare_with_db(participant)
+        compared.append({
+            "extracted": result.extracted,
+            "existing": result.existing,
+            "score": result.score,
+        })
+
+    return render_template("docx_review.html", stage="compare", compared=compared, eid=eid)
+
+
+@docx_upload_bp.post("/commit")
+@login_required
+def commit_docx():
+    service = DocxImportService()
+    eid = request.form.get("eid", "")
+    participants_blob = request.form.get("participants_json", "[]")
+    participants = json.loads(participants_blob)
+
+    saved = 0
+    for participant in participants:
+        if participant.get("_skip"):
+            continue
+        service.save_participant(participant, eid)
+        saved += 1
+
+    flash(f"Saved {saved} participant(s) and linked to event {eid}.", "success")
+    return redirect(url_for("docx_upload.upload_docx"))

--- a/routes/docx_upload.py
+++ b/routes/docx_upload.py
@@ -18,7 +18,7 @@ docx_upload_bp = Blueprint("docx_upload", __name__, url_prefix="/upload/docx")
 @login_required
 def upload_docx():
     if request.method == "GET":
-        return render_template("docx_review.html", participants=[], stage="upload")
+        return render_template("docx_upload.html")
 
     eid = (request.form.get("eid") or "").strip()
     files = request.files.getlist("files")

--- a/services/docx_import_service.py
+++ b/services/docx_import_service.py
@@ -8,7 +8,10 @@ from typing import Any
 from repositories.participant_event_repository import ParticipantEventRepository
 from repositories.participant_repository import ParticipantRepository
 from utils.country_resolver import resolve_country_flexible
-from utils.docx_parser import parse_docx
+from utils.dates import date_to_iso
+from utils.docx_parser import extract_docx_text, parse_docx as parse_docx_legacy
+from utils.normalize_phones import normalize_phone
+from utils.openai_extractor import extract_participants as extract_participants_openai
 from utils.names import _to_app_display_name
 
 
@@ -39,7 +42,16 @@ class DocxImportService:
         return {"participants": participants, "eid": eid}
 
     def parse_docx(self, file_path: str) -> list[dict[str, Any]]:
-        return parse_docx(file_path)
+        text = extract_docx_text(file_path)
+        if text:
+            try:
+                extracted = extract_participants_openai(text)
+            except Exception:
+                extracted = []
+            if extracted:
+                return extracted
+
+        return parse_docx_legacy(file_path)
 
     def normalize_fields(self, data: dict[str, Any]) -> dict[str, Any]:
         normalized = dict(data)
@@ -69,6 +81,13 @@ class DocxImportService:
 
         if normalized.get("name"):
             normalized["name"] = _to_app_display_name(str(normalized["name"]))
+
+        if normalized.get("dob"):
+            normalized["dob"] = date_to_iso(normalized.get("dob")) or str(normalized.get("dob", ""))
+
+        phone_value = normalized.get("phone")
+        if phone_value:
+            normalized["phone"] = normalize_phone(str(phone_value)) or str(phone_value)
 
         return normalized
 

--- a/services/docx_import_service.py
+++ b/services/docx_import_service.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Any
+
+from repositories.participant_event_repository import ParticipantEventRepository
+from repositories.participant_repository import ParticipantRepository
+from utils.country_resolver import resolve_country_flexible
+from utils.docx_parser import parse_docx
+from utils.names import _to_app_display_name
+
+
+@dataclass
+class ComparisonResult:
+    extracted: dict[str, Any]
+    existing: dict[str, Any] | None
+    score: float
+
+
+class DocxImportService:
+    """Extract and persist participants from uploaded DOCX files."""
+
+    def __init__(self) -> None:
+        self.participant_repo = ParticipantRepository()
+        self.participant_event_repo = ParticipantEventRepository()
+
+    def extract_participants(self, files: list[str], eid: str) -> dict[str, Any]:
+        participants: list[dict[str, Any]] = []
+        for path in files:
+            for extracted in self.parse_docx(path):
+                normalized = self.normalize_fields(extracted)
+                participant_json = self.convert_to_participant_json(normalized)
+                participant_json["_source_file"] = os.path.basename(path)
+                participant_json["_eid"] = eid
+                participants.append(participant_json)
+
+        return {"participants": participants, "eid": eid}
+
+    def parse_docx(self, file_path: str) -> list[dict[str, Any]]:
+        return parse_docx(file_path)
+
+    def normalize_fields(self, data: dict[str, Any]) -> dict[str, Any]:
+        normalized = dict(data)
+        country_value = str(normalized.get("representing_country", ""))
+        if country_value:
+            resolved = resolve_country_flexible(country_value)
+            normalized["representing_country"] = resolved.get("cid", "") if resolved else ""
+
+        birth_country = str(normalized.get("birth_country", ""))
+        if birth_country:
+            resolved = resolve_country_flexible(birth_country)
+            normalized["birth_country"] = resolved.get("cid", "") if resolved else ""
+
+        if not normalized.get("birth_country") and normalized.get("representing_country"):
+            normalized["birth_country"] = normalized.get("representing_country", "")
+
+        citizenships = normalized.get("citizenships") or []
+        if isinstance(citizenships, str):
+            citizenships = [citizenships]
+        if not citizenships and normalized.get("representing_country"):
+            citizenships = [normalized["representing_country"]]
+        normalized["citizenships"] = [
+            resolve_country_flexible(value).get("cid")
+            for value in citizenships
+            if value and resolve_country_flexible(value)
+        ] or ([normalized["representing_country"]] if normalized.get("representing_country") else [])
+
+        if normalized.get("name"):
+            normalized["name"] = _to_app_display_name(str(normalized["name"]))
+
+        return normalized
+
+    def convert_to_participant_json(self, data: dict[str, Any]) -> dict[str, Any]:
+        defaults = {
+            "name": "",
+            "representing_country": "",
+            "gender": "",
+            "dob": "",
+            "pob": "",
+            "birth_country": "",
+            "citizenships": [],
+            "position": "",
+            "organization": "",
+            "rank": "",
+            "phone": "",
+            "email": "",
+            "diet_restrictions": "",
+            "bio_short": "",
+            "transportation": "",
+            "travel_doc_number": "",
+            "travel_doc_issue_date": "",
+            "travel_doc_expiry_date": "",
+            "travel_doc_issued_by": "",
+            "bank_name": "",
+            "iban": "",
+            "iban_type": "",
+            "swift": "",
+        }
+        payload = dict(defaults)
+        payload.update({k: v for k, v in data.items() if k in defaults})
+        return payload
+
+    def compare_with_db(self, participant: dict[str, Any]) -> ComparisonResult:
+        # strict candidate set by country + dob, then fuzzy on normalized name
+        country = participant.get("representing_country")
+        desired_dob = participant.get("dob")
+        extracted_name = _to_app_display_name(participant.get("name", ""))
+        candidates = self.participant_repo.find_by_country(country) if country else []
+
+        best = None
+        best_score = 0.0
+        for candidate in candidates:
+            if desired_dob and candidate.dob:
+                candidate_dob = candidate.dob.date().isoformat()
+                if candidate_dob != desired_dob:
+                    continue
+            score = SequenceMatcher(None, extracted_name.lower(), candidate.name.lower()).ratio()
+            if score > best_score:
+                best_score = score
+                best = candidate
+
+        existing_payload = best.to_mongo() if best and best_score >= 0.78 else None
+        return ComparisonResult(extracted=participant, existing=existing_payload, score=best_score)
+
+    def save_participant(self, participant: dict[str, Any], eid: str) -> str:
+        comparison = self.compare_with_db(participant)
+        if comparison.existing:
+            pid = comparison.existing["pid"]
+            update_payload = {
+                key: value
+                for key, value in participant.items()
+                if key in comparison.existing and value not in (None, "")
+            }
+            update_payload.pop("pid", None)
+            self.participant_repo.update(pid, update_payload)
+        else:
+            pid = self.participant_repo.generate_next_pid()
+            model_payload = dict(participant)
+            model_payload.update({"pid": pid, "grade": 1, "gender": participant.get("gender") or "Male"})
+            from domain.models.participant import Participant
+
+            participant_model = Participant.model_validate(model_payload, context={"allow_missing_dob": True})
+            self.participant_repo.save(participant_model)
+
+        self.participant_event_repo.ensure_link(participant_id=pid, event_id=eid)
+        return pid

--- a/templates/base.html
+++ b/templates/base.html
@@ -27,9 +27,18 @@
             <a class="nav-link{% if request.endpoint and request.endpoint.startswith('events.') %} active{% endif %}"
              href="{{ url_for('events.show_events') }}">Events</a>
         </li>
-        <li class="nav-item">
-            <a class="nav-link{% if request.endpoint and request.endpoint.startswith('imports.') %} active{% endif %}"
-             href="{{ url_for('imports.upload_form') }}">Import</a>
+        <li class="nav-item dropdown">
+            {% set import_active = request.endpoint and (request.endpoint.startswith('imports.') or request.endpoint.startswith('docx_upload.')) %}
+            <a class="nav-link dropdown-toggle{% if import_active %} active{% endif %}" href="#" role="button"
+               data-bs-toggle="dropdown" aria-expanded="false">
+              Import
+            </a>
+            <ul class="dropdown-menu">
+              <li><a class="dropdown-item{% if request.endpoint and request.endpoint.startswith('imports.') %} active{% endif %}"
+                     href="{{ url_for('imports.upload_form') }}">Event</a></li>
+              <li><a class="dropdown-item{% if request.endpoint and request.endpoint.startswith('docx_upload.') %} active{% endif %}"
+                     href="{{ url_for('docx_upload.upload_docx') }}">Docx</a></li>
+            </ul>
         </li>
       </ul>
 

--- a/templates/docx_review.html
+++ b/templates/docx_review.html
@@ -44,7 +44,8 @@
   <input type="hidden" name="eid" value="{{ eid }}">
   <input type="hidden" name="participants_json" id="commitParticipantsJson">
   {% for item in compared %}
-  <div class="card mb-3 comparison-card" data-index="{{ loop.index0 }}">
+  {% set outer_index = loop.index0 %}
+  <div class="card mb-3 comparison-card" data-index="{{ outer_index }}">
     <div class="card-header">
       <strong>{{ item.extracted.name }}</strong>
       {% if item.existing %}
@@ -65,12 +66,12 @@
             <td>
               {% if item.existing %}
               <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" name="choice_{{ loop.parent.index0 }}_{{ key }}" value="existing" checked>
+                <input class="form-check-input" type="radio" name="choice_{{ outer_index }}_{{ key }}" value="existing" checked>
                 <label class="form-check-label">Keep DB</label>
               </div>
               {% endif %}
               <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" name="choice_{{ loop.parent.index0 }}_{{ key }}" value="extracted" {% if not item.existing %}checked{% endif %}>
+                <input class="form-check-input" type="radio" name="choice_{{ outer_index }}_{{ key }}" value="extracted" {% if not item.existing %}checked{% endif %}>
                 <label class="form-check-label">Use extracted</label>
               </div>
             </td>

--- a/templates/docx_review.html
+++ b/templates/docx_review.html
@@ -1,0 +1,143 @@
+{% extends "base.html" %}
+{% block title %}DOCX Bulk Upload{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <div>
+    <h1 class="h3 mb-1">Bulk DOCX Upload</h1>
+    <p class="text-muted mb-0">Upload participant registration Word files, review extraction, and confirm DB updates.</p>
+  </div>
+</div>
+
+{% if stage == 'upload' %}
+<form method="post" enctype="multipart/form-data" class="card card-body">
+  <div class="row g-3">
+    <div class="col-md-4">
+      <label class="form-label" for="eid">Event ID (eid)</label>
+      <input class="form-control" id="eid" name="eid" placeholder="PFE25M1" required>
+    </div>
+    <div class="col-md-8">
+      <label class="form-label" for="files">DOCX files</label>
+      <input class="form-control" id="files" type="file" name="files" accept=".docx" multiple required>
+    </div>
+  </div>
+  <div class="mt-3">
+    <button class="btn btn-primary" type="submit">Extract participants</button>
+  </div>
+</form>
+{% endif %}
+
+{% if stage == 'review' %}
+<form method="post" action="{{ url_for('docx_upload.compare_docx') }}" id="reviewForm">
+  <input type="hidden" name="eid" value="{{ eid }}">
+  <input type="hidden" name="participants_json" id="participantsJson">
+  <div class="alert alert-info">Review extracted entries. You can edit inline before comparison.</div>
+  {% for participant in participants %}
+  <div class="card mb-3 participant-card" data-index="{{ loop.index0 }}">
+    <div class="card-header d-flex justify-content-between">
+      <strong>{{ participant.name or 'Unnamed participant' }}</strong>
+      <span class="badge text-bg-secondary">{{ participant._source_file }}</span>
+    </div>
+    <div class="card-body">
+      <div class="row g-2">
+        {% for key, value in participant.items() if not key.startswith('_') %}
+        <div class="col-md-4">
+          <label class="form-label small">{{ key }}</label>
+          <input class="form-control form-control-sm field-input" data-field="{{ key }}" value="{{ value if value is not iterable or value is string else value|join(',') }}">
+        </div>
+        {% endfor %}
+      </div>
+      <div class="form-check mt-2">
+        <input class="form-check-input skip-check" type="checkbox" id="skip_{{ loop.index0 }}">
+        <label class="form-check-label" for="skip_{{ loop.index0 }}">Skip this participant</label>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+  <button class="btn btn-primary" type="submit">Compare with database</button>
+</form>
+{% endif %}
+
+{% if stage == 'compare' %}
+<form method="post" action="{{ url_for('docx_upload.commit_docx') }}" id="compareForm">
+  <input type="hidden" name="eid" value="{{ eid }}">
+  <input type="hidden" name="participants_json" id="commitParticipantsJson">
+  {% for item in compared %}
+  <div class="card mb-3 comparison-card" data-index="{{ loop.index0 }}">
+    <div class="card-header">
+      <strong>{{ item.extracted.name }}</strong>
+      {% if item.existing %}
+      <span class="badge text-bg-warning">Matched ({{ '%.2f'|format(item.score) }})</span>
+      {% else %}
+      <span class="badge text-bg-success">New participant</span>
+      {% endif %}
+    </div>
+    <div class="card-body">
+      <table class="table table-sm align-middle">
+        <thead><tr><th>Field</th><th>Database</th><th>Extracted</th><th>Choice</th></tr></thead>
+        <tbody>
+          {% for key, value in item.extracted.items() if not key.startswith('_') %}
+          <tr data-field="{{ key }}" data-extracted="{{ value }}" data-existing="{{ item.existing.get(key, '') if item.existing else '' }}">
+            <td>{{ key }}</td>
+            <td>{{ item.existing.get(key, '') if item.existing else '' }}</td>
+            <td>{{ value }}</td>
+            <td>
+              {% if item.existing %}
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="choice_{{ loop.parent.index0 }}_{{ key }}" value="existing" checked>
+                <label class="form-check-label">Keep DB</label>
+              </div>
+              {% endif %}
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="choice_{{ loop.parent.index0 }}_{{ key }}" value="extracted" {% if not item.existing %}checked{% endif %}>
+                <label class="form-check-label">Use extracted</label>
+              </div>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {% endfor %}
+  <button class="btn btn-success" type="submit">Confirm and save</button>
+</form>
+{% endif %}
+
+<script>
+  function serializeReview() {
+    const cards = document.querySelectorAll('.participant-card');
+    const result = [];
+    cards.forEach(card => {
+      const payload = {};
+      card.querySelectorAll('.field-input').forEach(input => {
+        payload[input.dataset.field] = input.value;
+      });
+      payload._skip = card.querySelector('.skip-check')?.checked || false;
+      result.push(payload);
+    });
+    const hidden = document.getElementById('participantsJson');
+    if (hidden) hidden.value = JSON.stringify(result);
+  }
+
+  function serializeCompare() {
+    const cards = document.querySelectorAll('.comparison-card');
+    const participants = [];
+    cards.forEach((card, cardIndex) => {
+      const payload = {};
+      card.querySelectorAll('tr[data-field]').forEach(row => {
+        const field = row.dataset.field;
+        const extracted = row.dataset.extracted;
+        const existing = row.dataset.existing;
+        const selected = row.querySelector('input:checked');
+        payload[field] = selected && selected.value === 'existing' ? existing : extracted;
+      });
+      participants.push(payload);
+    });
+    const hidden = document.getElementById('commitParticipantsJson');
+    if (hidden) hidden.value = JSON.stringify(participants);
+  }
+
+  document.getElementById('reviewForm')?.addEventListener('submit', serializeReview);
+  document.getElementById('compareForm')?.addEventListener('submit', serializeCompare);
+</script>
+{% endblock %}

--- a/templates/docx_review.html
+++ b/templates/docx_review.html
@@ -8,24 +8,6 @@
   </div>
 </div>
 
-{% if stage == 'upload' %}
-<form method="post" enctype="multipart/form-data" class="card card-body">
-  <div class="row g-3">
-    <div class="col-md-4">
-      <label class="form-label" for="eid">Event ID (eid)</label>
-      <input class="form-control" id="eid" name="eid" placeholder="PFE25M1" required>
-    </div>
-    <div class="col-md-8">
-      <label class="form-label" for="files">DOCX files</label>
-      <input class="form-control" id="files" type="file" name="files" accept=".docx" multiple required>
-    </div>
-  </div>
-  <div class="mt-3">
-    <button class="btn btn-primary" type="submit">Extract participants</button>
-  </div>
-</form>
-{% endif %}
-
 {% if stage == 'review' %}
 <form method="post" action="{{ url_for('docx_upload.compare_docx') }}" id="reviewForm">
   <input type="hidden" name="eid" value="{{ eid }}">

--- a/templates/docx_upload.html
+++ b/templates/docx_upload.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block title %}DOCX Upload{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <div>
+    <h1 class="h3 mb-1">Bulk DOCX Upload</h1>
+    <p class="text-muted mb-0">Upload one or more registration Word files for extraction.</p>
+  </div>
+</div>
+
+<form method="post" enctype="multipart/form-data" class="card card-body">
+  <div class="row g-3">
+    <div class="col-md-4">
+      <label class="form-label" for="eid">Event ID (eid)</label>
+      <input class="form-control" id="eid" name="eid" placeholder="PFE25M1" required>
+    </div>
+    <div class="col-md-8">
+      <label class="form-label" for="files">DOCX files</label>
+      <input class="form-control" id="files" type="file" name="files" accept=".docx" multiple required>
+    </div>
+  </div>
+  <div class="mt-3">
+    <button class="btn btn-primary" type="submit">Extract participants</button>
+  </div>
+</form>
+{% endblock %}

--- a/tests/test_docx_parser.py
+++ b/tests/test_docx_parser.py
@@ -1,0 +1,40 @@
+from docx import Document
+
+from utils.docx_parser import parse_docx
+
+
+def test_parse_docx_pattern_1(tmp_path):
+    file_path = tmp_path / "form.docx"
+    doc = Document()
+    table = doc.add_table(rows=2, cols=4)
+    table.cell(0, 0).text = "NAME & LAST NAME"
+    table.cell(0, 1).text = "Dragan Mektic"
+    table.cell(0, 2).text = "DOB"
+    table.cell(0, 3).text = "Dec/24/1956"
+    table.cell(1, 0).text = "GENDER"
+    table.cell(1, 1).text = "Male"
+    table.cell(1, 2).text = "COUNTRY"
+    table.cell(1, 3).text = "BiH"
+    doc.save(file_path)
+
+    participants = parse_docx(str(file_path))
+
+    assert len(participants) == 1
+    assert participants[0]["name"] == "Dragan Mektic"
+    assert participants[0]["dob"] == "1956-12-24"
+    assert participants[0]["gender"] == "Male"
+
+
+def test_parse_docx_pattern_3(tmp_path):
+    file_path = tmp_path / "list.docx"
+    doc = Document()
+    doc.add_paragraph("4. Makedonija")
+    doc.add_paragraph("1. Dragi ZLATANOVSKI (13. 2. 1965.)")
+    doc.save(file_path)
+
+    participants = parse_docx(str(file_path))
+
+    assert len(participants) == 1
+    assert participants[0]["name"] == "Dragi ZLATANOVSKI"
+    assert participants[0]["dob"] == "1965-02-13"
+    assert participants[0]["representing_country"] == "Makedonija"

--- a/tests/test_docx_review_template.py
+++ b/tests/test_docx_review_template.py
@@ -1,0 +1,38 @@
+from flask import Flask, render_template
+from pathlib import Path
+
+
+def _build_app() -> Flask:
+    root = Path(__file__).resolve().parents[1]
+    app = Flask(__name__, template_folder=str(root / "templates"), static_folder=str(root / "static"))
+    app.secret_key = "test"
+
+    app.add_url_rule("/home", endpoint="main.show_home", view_func=lambda: "home")
+    app.add_url_rule("/participants", endpoint="participants.show_participants", view_func=lambda: "participants")
+    app.add_url_rule("/events", endpoint="events.show_events", view_func=lambda: "events")
+    app.add_url_rule("/imports", endpoint="imports.upload_form", view_func=lambda: "imports")
+    app.add_url_rule("/docx", endpoint="docx_upload.upload_docx", view_func=lambda: "docx")
+    app.add_url_rule("/docx/commit", endpoint="docx_upload.commit_docx", view_func=lambda: "commit", methods=["POST"])
+    app.add_url_rule("/docx/compare", endpoint="docx_upload.compare_docx", view_func=lambda: "compare", methods=["POST"])
+    app.add_url_rule("/login", endpoint="auth.login", view_func=lambda: "login")
+    app.add_url_rule("/logout", endpoint="auth.logout", view_func=lambda: "logout", methods=["POST"])
+
+    return app
+
+
+def test_docx_compare_template_renders_without_loop_parent_error() -> None:
+    app = _build_app()
+    compared = [
+        {
+            "extracted": {"name": "Alice Doe", "email": "alice@example.com"},
+            "existing": {"name": "Alice Doe", "email": "old@example.com"},
+            "score": 0.93,
+        }
+    ]
+
+    with app.test_request_context("/docx"):
+        html = render_template("docx_review.html", stage="compare", compared=compared, eid="E001")
+
+    assert "choice_0_name" in html
+    assert "choice_0_email" in html
+    assert "Matched (0.93)" in html

--- a/tests/test_openai_extractor.py
+++ b/tests/test_openai_extractor.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from utils.docx_parser import extract_docx_text
+from utils.openai_extractor import extract_participants
+from docx import Document
+
+
+class _FakeResponses:
+    def __init__(self, output_text: str) -> None:
+        self._output_text = output_text
+
+    def create(self, **_kwargs):
+        class _Resp:
+            def __init__(self, output_text: str) -> None:
+                self.output_text = output_text
+
+        return _Resp(self._output_text)
+
+
+class _FakeClient:
+    def __init__(self, output_text: str) -> None:
+        self.responses = _FakeResponses(output_text)
+
+
+def test_openai_extractor_parses_json_fence() -> None:
+    client = _FakeClient(
+        """```json
+{"participants":[{"name":"Jane Doe","citizenships":"C001"}]}
+```"""
+    )
+
+    participants = extract_participants("sample text", client=client)
+
+    assert len(participants) == 1
+    assert participants[0]["name"] == "Jane Doe"
+    assert participants[0]["citizenships"] == ["C001"]
+
+
+def test_extract_docx_text_reads_paragraphs_and_table(tmp_path) -> None:
+    file_path = tmp_path / "sample.docx"
+    doc = Document()
+    doc.add_paragraph("Header")
+    table = doc.add_table(rows=1, cols=2)
+    table.cell(0, 0).text = "NAME"
+    table.cell(0, 1).text = "John Doe"
+    doc.save(file_path)
+
+    text = extract_docx_text(str(file_path))
+
+    assert "Header" in text
+    assert "NAME" in text
+    assert "John Doe" in text

--- a/tests/test_openai_extractor.py
+++ b/tests/test_openai_extractor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from utils.docx_parser import extract_docx_text
-from utils.openai_extractor import extract_participants
+from utils.openai_extractor import _resolve_api_key, extract_participants
 from docx import Document
 
 
@@ -50,3 +50,17 @@ def test_extract_docx_text_reads_paragraphs_and_table(tmp_path) -> None:
     assert "Header" in text
     assert "NAME" in text
     assert "John Doe" in text
+
+
+def test_resolve_api_key_prefers_openai_then_custom(monkeypatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("extractionProjectAPI", raising=False)
+    monkeypatch.delenv("EXTRACTION_PROJECT_API", raising=False)
+
+    monkeypatch.setenv("extractionProjectAPI", "custom-key")
+    assert _resolve_api_key() == "custom-key"
+
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    assert _resolve_api_key() == "openai-key"
+
+    assert _resolve_api_key("explicit") == "explicit"

--- a/utils/docx_parser.py
+++ b/utils/docx_parser.py
@@ -181,6 +181,27 @@ def _extract_pattern_3(lines: list[str]) -> list[dict[str, Any]]:
     return participants
 
 
+def extract_docx_text(path: str, *, max_length: int = 12000) -> str:
+    """Extract plain text from DOCX paragraphs and tables for LLM parsing."""
+
+    doc = Document(path)
+    lines: list[str] = []
+
+    for paragraph in doc.paragraphs:
+        text = _clean(paragraph.text)
+        if text:
+            lines.append(text)
+
+    for table in doc.tables:
+        for row in table.rows:
+            for cell in row.cells:
+                text = _clean(cell.text)
+                if text:
+                    lines.append(text)
+
+    return "\n".join(lines)[:max_length]
+
+
 def parse_docx(path: str) -> list[dict[str, Any]]:
     """Parse a DOCX file and return best-effort participant dictionaries."""
 

--- a/utils/docx_parser.py
+++ b/utils/docx_parser.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any
+
+from docx import Document
+
+_LABEL_ALIASES = {
+    "country": "representing_country",
+    "name & last name": "name",
+    "name": "name",
+    "name last name": "name",
+    "dob": "dob",
+    "date of birth": "dob",
+    "pob": "pob",
+    "place of birth": "pob",
+    "passport number": "travel_doc_number",
+    "gender": "gender",
+    "diet restrictions": "diet_restrictions",
+    "institution": "organization",
+    "institution/organization": "organization",
+    "organization": "organization",
+    "position": "position",
+    "rank": "rank",
+    "phone": "phone",
+    "email": "email",
+    "transportation": "transportation",
+    "arrival": "arrival",
+    "departure": "departure",
+    "short professional biography": "bio_short",
+}
+
+_DATE_FORMATS = [
+    "%B/%d/%Y",
+    "%b/%d/%Y",
+    "%m/%d/%Y",
+    "%m/%d/%y",
+    "%d/%m/%Y",
+    "%d.%m.%Y",
+    "%d. %m. %Y",
+]
+
+
+def _clean(text: str) -> str:
+    return re.sub(r"\s+", " ", (text or "").replace("\xa0", " ")).strip()
+
+
+def _normalize_label(label: str) -> str:
+    normalized = re.sub(r"\s+", " ", label.lower()).strip(" :")
+    return _LABEL_ALIASES.get(normalized, normalized.replace(" ", "_"))
+
+
+def _normalize_date(raw: str) -> str:
+    value = _clean(raw).strip("./")
+    if not value:
+        return ""
+
+    value = value.replace("-", "/")
+    value = re.sub(r"\s+", "", value)
+
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.strptime(value, fmt).strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+
+    # Serbian/Croatian style: 13. 2. 1965.
+    m = re.match(r"^(\d{1,2})\.?[./](\d{1,2})\.?[./](\d{2,4})\.?$", value)
+    if m:
+        day, month, year = m.groups()
+        year = year if len(year) == 4 else f"19{year}"
+        try:
+            return datetime(int(year), int(month), int(day)).strftime("%Y-%m-%d")
+        except ValueError:
+            return ""
+    return ""
+
+
+def _normalize_gender(raw: str) -> str:
+    text = _clean(raw).lower()
+    if text in {"f", "female", "famele"}:
+        return "Female"
+    if text in {"m", "male"}:
+        return "Male"
+    return ""
+
+
+def _normalize_bool(raw: str) -> bool | str:
+    text = _clean(raw).lower()
+    if text in {"no", "n"}:
+        return False
+    if text in {"yes", "y"}:
+        return True
+    return ""
+
+
+def _extract_pattern_1(doc: Document) -> list[dict[str, Any]]:
+    participants: list[dict[str, Any]] = []
+    for table in doc.tables:
+        fields: dict[str, Any] = {}
+        for row in table.rows:
+            cells = [_clean(cell.text) for cell in row.cells if _clean(cell.text)]
+            if len(cells) < 2:
+                continue
+            i = 0
+            while i + 1 < len(cells):
+                key = _normalize_label(cells[i])
+                fields[key] = cells[i + 1]
+                i += 2
+
+        if fields.get("name"):
+            participants.append(fields)
+    return participants
+
+
+def _extract_pattern_2(lines: list[str]) -> list[dict[str, Any]]:
+    participants: list[dict[str, Any]] = []
+    date_pattern = re.compile(r"(\d{1,2}[/.]\d{1,2}[/.]\d{2,4})")
+
+    for line in lines:
+        if not date_pattern.search(line):
+            continue
+        parts = re.split(r"\t+|\s{2,}", line)
+        if len(parts) < 3:
+            continue
+
+        name = _clean(parts[0])
+        dob_match = date_pattern.search(line)
+        if not name or not dob_match:
+            continue
+
+        rank = _clean(parts[2]) if len(parts) > 2 else ""
+        tail = _clean(parts[3]) if len(parts) > 3 else ""
+        position, _, organization = tail.partition(",")
+        if "/" in position and not organization:
+            position, _, organization = position.partition("/")
+
+        participants.append(
+            {
+                "name": name,
+                "dob": dob_match.group(1),
+                "rank": rank,
+                "position": _clean(position),
+                "organization": _clean(organization),
+            }
+        )
+
+    return participants
+
+
+def _extract_pattern_3(lines: list[str]) -> list[dict[str, Any]]:
+    participants: list[dict[str, Any]] = []
+    country = ""
+    country_header = re.compile(r"^\d+\.\s+(.+)$")
+    list_item = re.compile(r"^\d+\.\s+([A-Za-zČĆŽŠĐčćžšđ\-\s]+)(?:\(|$)")
+
+    for line in lines:
+        header_match = country_header.match(line)
+        has_date = bool(re.search(r"\d{1,2}[./]\s*\d{1,2}[./]", line))
+        if header_match and len(header_match.group(1).split()) <= 4 and not has_date:
+            country = _clean(header_match.group(1))
+            continue
+
+        m = list_item.match(line)
+        if not m:
+            continue
+
+        name = _clean(m.group(1))
+        if not name:
+            continue
+
+        dob_match = re.search(r"\(([^)]+)\)", line)
+        participants.append(
+            {
+                "name": name,
+                "dob": dob_match.group(1) if dob_match else "",
+                "representing_country": country,
+            }
+        )
+    return participants
+
+
+def parse_docx(path: str) -> list[dict[str, Any]]:
+    """Parse a DOCX file and return best-effort participant dictionaries."""
+
+    doc = Document(path)
+    lines = [_clean(p.text) for p in doc.paragraphs if _clean(p.text)]
+
+    participants = _extract_pattern_1(doc)
+    if not participants:
+        participants = _extract_pattern_2(lines)
+    if not participants:
+        participants = _extract_pattern_3(lines)
+
+    normalized: list[dict[str, Any]] = []
+    for participant in participants:
+        item = dict(participant)
+        if "dob" in item:
+            item["dob"] = _normalize_date(str(item.get("dob", "")))
+        if "arrival" in item:
+            item["arrival"] = _normalize_date(str(item.get("arrival", "")))
+        if "departure" in item:
+            item["departure"] = _normalize_date(str(item.get("departure", "")))
+        if "gender" in item:
+            item["gender"] = _normalize_gender(str(item.get("gender", "")))
+        if "diet_restrictions" in item:
+            maybe_bool = _normalize_bool(str(item.get("diet_restrictions", "")))
+            if maybe_bool != "":
+                item["diet_restrictions"] = maybe_bool
+        normalized.append(item)
+
+    return normalized

--- a/utils/openai_extractor.py
+++ b/utils/openai_extractor.py
@@ -51,10 +51,21 @@ def _build_prompt(document_text: str) -> str:
     )
 
 
+def _resolve_api_key(explicit_key: str | None = None) -> str | None:
+    if explicit_key:
+        return explicit_key
+
+    return (
+        os.getenv("OPENAI_API_KEY")
+        or os.getenv("extractionProjectAPI")
+        or os.getenv("EXTRACTION_PROJECT_API")
+    )
+
+
 def _get_client(api_key: str | None = None):
     from openai import OpenAI
 
-    return OpenAI(api_key=api_key or os.getenv("OPENAI_API_KEY"))
+    return OpenAI(api_key=_resolve_api_key(api_key))
 
 
 def _extract_json_payload(raw_text: str) -> dict[str, Any] | list[Any]:

--- a/utils/openai_extractor.py
+++ b/utils/openai_extractor.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+MODEL = os.getenv("OPENAI_EXTRACTION_MODEL", "gpt-4.1")
+MAX_LENGTH = 12000
+
+_PARTICIPANT_FIELDS = [
+    "name",
+    "representing_country",
+    "gender",
+    "dob",
+    "pob",
+    "birth_country",
+    "citizenships",
+    "position",
+    "organization",
+    "rank",
+    "phone",
+    "email",
+    "diet_restrictions",
+    "bio_short",
+    "transportation",
+    "travel_doc_number",
+    "travel_doc_issue_date",
+    "travel_doc_expiry_date",
+    "travel_doc_issued_by",
+    "bank_name",
+    "iban",
+    "iban_type",
+    "swift",
+]
+
+
+def _build_prompt(document_text: str) -> str:
+    fields = "\n".join(_PARTICIPANT_FIELDS)
+    return (
+        "You are a document data extraction engine.\n"
+        "Extract participants from the provided document and return ONLY valid JSON.\n\n"
+        "Return a JSON object with key 'participants' and array values.\n"
+        "Each participant must contain these fields:\n"
+        f"{fields}\n\n"
+        "Rules:\n"
+        "- If missing, use empty string for scalar fields and [] for citizenships\n"
+        "- Date format must be YYYY-MM-DD\n"
+        "- Detect multiple participants and all supported languages\n"
+        "- Do not include markdown code fences\n\n"
+        f"DOCUMENT:\n{document_text[:MAX_LENGTH]}"
+    )
+
+
+def _get_client(api_key: str | None = None):
+    from openai import OpenAI
+
+    return OpenAI(api_key=api_key or os.getenv("OPENAI_API_KEY"))
+
+
+def _extract_json_payload(raw_text: str) -> dict[str, Any] | list[Any]:
+    text = (raw_text or "").strip()
+    if not text:
+        return {"participants": []}
+
+    if text.startswith("```"):
+        text = text.strip("`")
+        text = text.replace("json\n", "", 1).strip()
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        start_obj = text.find("{")
+        end_obj = text.rfind("}")
+        if start_obj != -1 and end_obj != -1 and end_obj > start_obj:
+            return json.loads(text[start_obj : end_obj + 1])
+
+        start_arr = text.find("[")
+        end_arr = text.rfind("]")
+        if start_arr != -1 and end_arr != -1 and end_arr > start_arr:
+            return json.loads(text[start_arr : end_arr + 1])
+
+        raise
+
+
+def extract_participants(text: str, *, client=None, model: str = MODEL) -> list[dict[str, Any]]:
+    """Extract participants from raw text using OpenAI responses API."""
+
+    if not (text or "").strip():
+        return []
+
+    resolved_client = client or _get_client()
+    response = resolved_client.responses.create(
+        model=model,
+        input=[{"role": "user", "content": _build_prompt(text)}],
+        temperature=0,
+    )
+    payload = _extract_json_payload(response.output_text)
+
+    participants: list[dict[str, Any]]
+    if isinstance(payload, dict):
+        raw_participants = payload.get("participants") or []
+        participants = [entry for entry in raw_participants if isinstance(entry, dict)]
+    elif isinstance(payload, list):
+        participants = [entry for entry in payload if isinstance(entry, dict)]
+    else:
+        participants = []
+
+    normalized: list[dict[str, Any]] = []
+    for participant in participants:
+        row = {field: (participant.get(field, []) if field == "citizenships" else participant.get(field, "")) for field in _PARTICIPANT_FIELDS}
+        if not isinstance(row.get("citizenships"), list):
+            row["citizenships"] = [str(row.get("citizenships", ""))] if row.get("citizenships") else []
+        normalized.append(row)
+
+    return normalized


### PR DESCRIPTION
### Motivation
- Provide a workflow to ingest multiple `.docx` registration files, extract participants, normalize fields, and integrate with the existing event/participant model and upload UI.
- Reuse existing normalization and country-resolution utilities so extracted data matches the tracker JSON and MongoDB expectations.
- Allow user review and field-by-field comparison with fuzzy DB matching before creating/updating participants and linking them to an event.

### Description
- Added a DOCX parser utility `utils/docx_parser.py` that supports three patterns: table-based registration forms, row-based attendee lines, and simple numbered name lists, with label normalization and DOB/gender/boolean/date normalization during extraction.
- Implemented `DocxImportService` in `services/docx_import_service.py` providing `extract_participants`, `parse_docx`, `normalize_fields`, `convert_to_participant_json`, `compare_with_db`, and `save_participant` to orchestrate normalization, conversion to tracker-compatible participant JSON, fuzzy matching (name similarity scoped by country/dob), upsert/create logic, and linking via `participant_events`.
- Added Flask routes in `routes/docx_upload.py` for the new UI: `GET/POST /upload/docx` (upload + extraction preview), `POST /upload/docx/compare` (DB comparison stage), and `POST /upload/docx/commit` (final save and event assignment); uploaded files are persisted under `uploads/docx/` as `<timestamp>_<filename>.docx` for audit.
- Added a review/compare template `templates/docx_review.html` allowing inline edit/skip of extracted entries and a field-by-field DB vs extracted comparison where the user chooses per-field values before commit.
- Added parser unit tests `tests/test_docx_parser.py` and appended `python-docx==1.1.2` to `requirements.txt`.

### Testing
- Ran `pytest -q tests/test_docx_parser.py` and the parser tests passed (`2 passed`).
- Ran `python -m compileall services/docx_import_service.py utils/docx_parser.py routes/docx_upload.py` to validate modules compiled successfully.
- Ran `pytest -q tests/test_import_routes.py` which failed in this environment due to existing import-route test expectations and the test-suite setup (these failures are unrelated to the DOCX parser additions).
- Attempted to start the app for a UI screenshot, but the local Flask startup failed in this environment due to Mongo DB SRV DNS resolution errors, so end-to-end browser capture could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84235233483229018ebd87929f74c)