### PR TITLE
Add DOCX bulk upload, parsing, OpenAI extractor, review UI and tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,6 @@ python-dateutil==2.9.0.post0
 tzdata==2025.2
 requests
 
+
+python-docx==1.1.2
+openai==1.66.3

--- a/routes/docx_upload.py
+++ b/routes/docx_upload.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+
+from flask import Blueprint, current_app, flash, redirect, render_template, request, url_for
+from werkzeug.utils import secure_filename
+
+from middleware.auth import login_required
+from services.docx_import_service import DocxImportService
+
+
+docx_upload_bp = Blueprint("docx_upload", __name__, url_prefix="/upload/docx")
+
+
+@docx_upload_bp.route("", methods=["GET", "POST"], strict_slashes=False)
+@login_required
+def upload_docx():
+    if request.method == "GET":
+        return render_template("docx_upload.html")
+
+    eid = (request.form.get("eid") or "").strip()
+    files = request.files.getlist("files")
+    if not eid:
+        flash("Missing event id (eid).", "danger")
+        return redirect(url_for("docx_upload.upload_docx"))
+
+    if not files:
+        flash("Please choose at least one DOCX file.", "warning")
+        return redirect(url_for("docx_upload.upload_docx"))
+
+    upload_root = current_app.config.get("UPLOADS_DIR", os.path.join(os.getcwd(), "uploads"))
+    upload_dir = os.path.join(upload_root, "docx")
+    os.makedirs(upload_dir, exist_ok=True)
+
+    saved_files: list[str] = []
+    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    for file in files:
+        if not file.filename:
+            continue
+        filename = secure_filename(file.filename)
+        if not filename.lower().endswith(".docx"):
+            continue
+        full_name = f"{timestamp}_{filename}"
+        path = os.path.join(upload_dir, full_name)
+        file.save(path)
+        saved_files.append(path)
+
+    if not saved_files:
+        flash("No valid .docx files were provided.", "danger")
+        return redirect(url_for("docx_upload.upload_docx"))
+
+    service = DocxImportService()
+    bundle = service.extract_participants(saved_files, eid)
+
+    return render_template(
+        "docx_review.html",
+        participants=bundle["participants"],
+        eid=eid,
+        stage="review",
+    )
+
+
+@docx_upload_bp.post("/compare")
+@login_required
+def compare_docx():
+    service = DocxImportService()
+    eid = request.form.get("eid", "")
+    participants_blob = request.form.get("participants_json", "[]")
+    participants = json.loads(participants_blob)
+
+    compared = []
+    for participant in participants:
+        result = service.compare_with_db(participant)
+        compared.append({
+            "extracted": result.extracted,
+            "existing": result.existing,
+            "score": result.score,
+        })
+
+    return render_template("docx_review.html", stage="compare", compared=compared, eid=eid)
+
+
+@docx_upload_bp.post("/commit")
+@login_required
+def commit_docx():
+    service = DocxImportService()
+    eid = request.form.get("eid", "")
+    participants_blob = request.form.get("participants_json", "[]")
+    participants = json.loads(participants_blob)
+
+    saved = 0
+    for participant in participants:
+        if participant.get("_skip"):
+            continue
+        service.save_participant(participant, eid)
+        saved += 1
+
+    flash(f"Saved {saved} participant(s) and linked to event {eid}.", "success")
+    return redirect(url_for("docx_upload.upload_docx"))

--- a/routes/docx_upload.py
+++ b/routes/docx_upload.py
@@ -52,7 +52,12 @@ def upload_docx():
         return redirect(url_for("docx_upload.upload_docx"))
 
     service = DocxImportService()
-    bundle = service.extract_participants(saved_files, eid)
+    try:
+        bundle = service.extract_participants(saved_files, eid)
+    except Exception as exc:
+        flash(f"DOCX extraction failed: {exc}", "danger")
+        return redirect(url_for("docx_upload.upload_docx"))
+
     warnings = bundle.get("warnings", [])
     for message in warnings:
         flash(message, "warning")

--- a/routes/docx_upload.py
+++ b/routes/docx_upload.py
@@ -55,6 +55,7 @@ def upload_docx():
     try:
         bundle = service.extract_participants(saved_files, eid)
     except Exception as exc:
+        current_app.logger.exception("DOCX extraction failed")
         flash(f"DOCX extraction failed: {exc}", "danger")
         return redirect(url_for("docx_upload.upload_docx"))
 

--- a/routes/docx_upload.py
+++ b/routes/docx_upload.py
@@ -53,10 +53,14 @@ def upload_docx():
 
     service = DocxImportService()
     bundle = service.extract_participants(saved_files, eid)
+    warnings = bundle.get("warnings", [])
+    for message in warnings:
+        flash(message, "warning")
 
     return render_template(
         "docx_review.html",
         participants=bundle["participants"],
+        warnings=warnings,
         eid=eid,
         stage="review",
     )

--- a/services/docx_import_service.py
+++ b/services/docx_import_service.py
@@ -9,7 +9,7 @@ from repositories.participant_event_repository import ParticipantEventRepository
 from repositories.participant_repository import ParticipantRepository
 from utils.country_resolver import resolve_country_flexible
 from utils.dates import date_to_iso
-from utils.docx_parser import extract_docx_text, parse_docx as parse_docx_legacy
+from utils.docx_parser import extract_docx_text
 from utils.normalize_phones import normalize_phone
 from utils.openai_extractor import (
     _resolve_api_key,
@@ -28,6 +28,42 @@ class ComparisonResult:
 class DocxImportService:
     """Extract and persist participants from uploaded DOCX files."""
 
+    _PARTICIPANT_DEFAULTS: dict[str, Any] = {
+        "pid": "",
+        "representing_country": "",
+        "gender": "",
+        "grade": 1,
+        "name": "",
+        "dob": "",
+        "pob": "",
+        "birth_country": "",
+        "citizenships": [],
+        "email": "",
+        "phone": "",
+        "diet_restrictions": "",
+        "organization": "",
+        "unit": "",
+        "position": "",
+        "rank": "",
+        "intl_authority": "",
+        "bio_short": "",
+    }
+
+    _PARTICIPANT_EVENT_DEFAULTS: dict[str, Any] = {
+        "transportation": "",
+        "transport_other": "",
+        "traveling_from": "",
+        "returning_to": "",
+        "travel_doc_type": "",
+        "travel_doc_issue_date": "",
+        "travel_doc_expiry_date": "",
+        "travel_doc_issued_by": "",
+        "bank_name": "",
+        "iban": "",
+        "iban_type": "",
+        "swift": "",
+    }
+
     def __init__(self) -> None:
         self.participant_repo = ParticipantRepository()
         self.participant_event_repo = ParticipantEventRepository()
@@ -40,6 +76,7 @@ class DocxImportService:
             for extracted in extracted_rows:
                 normalized = self.normalize_fields(extracted)
                 participant_json = self.convert_to_participant_json(normalized)
+                participant_json.update(self.convert_to_participant_event_json(normalized))
                 participant_json["_source_file"] = os.path.basename(path)
                 participant_json["_eid"] = eid
                 participant_json["_extraction_engine"] = "openai"
@@ -104,40 +141,20 @@ class DocxImportService:
         return normalized
 
     def convert_to_participant_json(self, data: dict[str, Any]) -> dict[str, Any]:
-        """Project extracted values to Participant collection schema only.
+        """Project extracted values to Participant collection schema only."""
 
-        Excludes Mongo-managed/system fields such as _id/created_at/updated_at/_audit.
-        Missing values are kept as blank strings (or [] for citizenships).
-        """
-
-        defaults = {
-            "pid": "",
-            "representing_country": "",
-            "gender": "",
-            "grade": 1,
-            "name": "",
-            "dob": "",
-            "pob": "",
-            "birth_country": "",
-            "citizenships": [],
-            "email": "",
-            "phone": "",
-            "diet_restrictions": "",
-            "organization": "",
-            "unit": "",
-            "position": "",
-            "rank": "",
-            "intl_authority": "",
-            "bio_short": "",
-        }
-
-        payload = dict(defaults)
-        payload.update({k: v for k, v in data.items() if k in defaults})
+        payload = dict(self._PARTICIPANT_DEFAULTS)
+        payload.update({k: v for k, v in data.items() if k in self._PARTICIPANT_DEFAULTS})
         return payload
 
+    def convert_to_participant_event_json(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Project extracted values to participant_events schema-only fields."""
+
+        payload = dict(self._PARTICIPANT_EVENT_DEFAULTS)
+        payload.update({k: v for k, v in data.items() if k in self._PARTICIPANT_EVENT_DEFAULTS})
+        return payload
 
     def compare_with_db(self, participant: dict[str, Any]) -> ComparisonResult:
-        # strict candidate set by country + dob, then fuzzy on normalized name
         country = participant.get("representing_country")
         desired_dob = participant.get("dob")
         extracted_name = _to_app_display_name(participant.get("name", ""))
@@ -160,23 +177,34 @@ class DocxImportService:
 
     def save_participant(self, participant: dict[str, Any], eid: str) -> str:
         comparison = self.compare_with_db(participant)
+        participant_payload = self.convert_to_participant_json(participant)
+        event_payload = self.convert_to_participant_event_json(participant)
+
         if comparison.existing:
             pid = comparison.existing["pid"]
             update_payload = {
                 key: value
-                for key, value in participant.items()
+                for key, value in participant_payload.items()
                 if key in comparison.existing and value not in (None, "")
             }
             update_payload.pop("pid", None)
             self.participant_repo.update(pid, update_payload)
         else:
             pid = self.participant_repo.generate_next_pid()
-            model_payload = dict(participant)
-            model_payload.update({"pid": pid, "grade": 1, "gender": participant.get("gender") or "Male"})
+            model_payload = dict(participant_payload)
+            model_payload.update({"pid": pid, "grade": participant_payload.get("grade", 1), "gender": participant_payload.get("gender") or "Male"})
             from domain.models.participant import Participant
 
             participant_model = Participant.model_validate(model_payload, context={"allow_missing_dob": True})
             self.participant_repo.save(participant_model)
 
+        # update participant_events snapshot with event-scoped fields as provided
         self.participant_event_repo.ensure_link(participant_id=pid, event_id=eid)
+        event_update = {k: v for k, v in event_payload.items() if v not in (None, "")}
+        if event_update:
+            self.participant_event_repo.collection.update_one(
+                {"participant_id": pid, "event_id": eid},
+                {"$set": event_update},
+            )
+
         return pid

--- a/services/docx_import_service.py
+++ b/services/docx_import_service.py
@@ -104,42 +104,37 @@ class DocxImportService:
         return normalized
 
     def convert_to_participant_json(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Project extracted values to Participant collection schema only.
+
+        Excludes Mongo-managed/system fields such as _id/created_at/updated_at/_audit.
+        Missing values are kept as blank strings (or [] for citizenships).
+        """
+
         defaults = {
             "pid": "",
-            "name": "",
             "representing_country": "",
-            "transportation": "",
-            "transport_other": "",
-            "traveling_from": "",
-            "returning_to": "",
-            "grade": 1,
-            "position": "",
-            "phone": "",
-            "email": "",
             "gender": "",
+            "grade": 1,
+            "name": "",
             "dob": "",
             "pob": "",
             "birth_country": "",
             "citizenships": [],
-            "travel_doc_type": "",
-            "travel_doc_number": "",
-            "travel_doc_issue_date": "",
-            "travel_doc_expiry_date": "",
-            "travel_doc_issued_by": "",
+            "email": "",
+            "phone": "",
             "diet_restrictions": "",
             "organization": "",
             "unit": "",
+            "position": "",
             "rank": "",
             "intl_authority": "",
             "bio_short": "",
-            "bank_name": "",
-            "iban": "",
-            "iban_type": "",
-            "swift": "",
         }
+
         payload = dict(defaults)
         payload.update({k: v for k, v in data.items() if k in defaults})
         return payload
+
 
     def compare_with_db(self, participant: dict[str, Any]) -> ComparisonResult:
         # strict candidate set by country + dob, then fuzzy on normalized name

--- a/services/docx_import_service.py
+++ b/services/docx_import_service.py
@@ -11,7 +11,10 @@ from utils.country_resolver import resolve_country_flexible
 from utils.dates import date_to_iso
 from utils.docx_parser import extract_docx_text, parse_docx as parse_docx_legacy
 from utils.normalize_phones import normalize_phone
-from utils.openai_extractor import extract_participants as extract_participants_openai
+from utils.openai_extractor import (
+    _resolve_api_key,
+    extract_participants as extract_participants_openai,
+)
 from utils.names import _to_app_display_name
 
 
@@ -31,27 +34,48 @@ class DocxImportService:
 
     def extract_participants(self, files: list[str], eid: str) -> dict[str, Any]:
         participants: list[dict[str, Any]] = []
+        warnings: list[str] = []
         for path in files:
-            for extracted in self.parse_docx(path):
+            extracted_rows, engine, warning = self.parse_docx(path)
+            if warning:
+                warnings.append(f"{os.path.basename(path)}: {warning}")
+
+            for extracted in extracted_rows:
                 normalized = self.normalize_fields(extracted)
                 participant_json = self.convert_to_participant_json(normalized)
                 participant_json["_source_file"] = os.path.basename(path)
                 participant_json["_eid"] = eid
+                participant_json["_extraction_engine"] = engine
                 participants.append(participant_json)
 
-        return {"participants": participants, "eid": eid}
+        return {"participants": participants, "eid": eid, "warnings": warnings}
 
-    def parse_docx(self, file_path: str) -> list[dict[str, Any]]:
+    def parse_docx(self, file_path: str) -> tuple[list[dict[str, Any]], str, str | None]:
         text = extract_docx_text(file_path)
-        if text:
-            try:
-                extracted = extract_participants_openai(text)
-            except Exception:
-                extracted = []
-            if extracted:
-                return extracted
 
-        return parse_docx_legacy(file_path)
+        if not text:
+            return parse_docx_legacy(file_path), "legacy", "Document text was empty; used legacy parser."
+
+        api_key = _resolve_api_key()
+        if not api_key:
+            return parse_docx_legacy(file_path), "legacy", (
+                "OpenAI API key is not configured (OPENAI_API_KEY/extractionProjectAPI); "
+                "used legacy parser."
+            )
+
+        try:
+            extracted = extract_participants_openai(text)
+        except Exception as exc:
+            return parse_docx_legacy(file_path), "legacy", (
+                f"OpenAI extraction failed ({exc}); used legacy parser."
+            )
+
+        if extracted:
+            return extracted, "openai", None
+
+        return parse_docx_legacy(file_path), "legacy", (
+            "OpenAI extraction returned no participants; used legacy parser."
+        )
 
     def normalize_fields(self, data: dict[str, Any]) -> dict[str, Any]:
         normalized = dict(data)

--- a/services/docx_import_service.py
+++ b/services/docx_import_service.py
@@ -34,48 +34,36 @@ class DocxImportService:
 
     def extract_participants(self, files: list[str], eid: str) -> dict[str, Any]:
         participants: list[dict[str, Any]] = []
-        warnings: list[str] = []
         for path in files:
-            extracted_rows, engine, warning = self.parse_docx(path)
-            if warning:
-                warnings.append(f"{os.path.basename(path)}: {warning}")
+            extracted_rows = self.parse_docx(path)
 
             for extracted in extracted_rows:
                 normalized = self.normalize_fields(extracted)
                 participant_json = self.convert_to_participant_json(normalized)
                 participant_json["_source_file"] = os.path.basename(path)
                 participant_json["_eid"] = eid
-                participant_json["_extraction_engine"] = engine
+                participant_json["_extraction_engine"] = "openai"
                 participants.append(participant_json)
 
-        return {"participants": participants, "eid": eid, "warnings": warnings}
+        return {"participants": participants, "eid": eid, "warnings": []}
 
-    def parse_docx(self, file_path: str) -> tuple[list[dict[str, Any]], str, str | None]:
+    def parse_docx(self, file_path: str) -> list[dict[str, Any]]:
         text = extract_docx_text(file_path)
 
         if not text:
-            return parse_docx_legacy(file_path), "legacy", "Document text was empty; used legacy parser."
+            raise ValueError("Document text is empty; cannot extract participants with OpenAI-only mode.")
 
         api_key = _resolve_api_key()
         if not api_key:
-            return parse_docx_legacy(file_path), "legacy", (
-                "OpenAI API key is not configured (OPENAI_API_KEY/extractionProjectAPI); "
-                "used legacy parser."
+            raise RuntimeError(
+                "OpenAI API key is not configured. Set OPENAIAPI (or OPENAI_API_KEY)."
             )
 
-        try:
-            extracted = extract_participants_openai(text)
-        except Exception as exc:
-            return parse_docx_legacy(file_path), "legacy", (
-                f"OpenAI extraction failed ({exc}); used legacy parser."
-            )
+        extracted = extract_participants_openai(text)
+        if not extracted:
+            raise ValueError("OpenAI extraction returned no participants.")
 
-        if extracted:
-            return extracted, "openai", None
-
-        return parse_docx_legacy(file_path), "legacy", (
-            "OpenAI extraction returned no participants; used legacy parser."
-        )
+        return extracted
 
     def normalize_fields(self, data: dict[str, Any]) -> dict[str, Any]:
         normalized = dict(data)

--- a/services/docx_import_service.py
+++ b/services/docx_import_service.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Any
+
+from repositories.participant_event_repository import ParticipantEventRepository
+from repositories.participant_repository import ParticipantRepository
+from utils.country_resolver import resolve_country_flexible
+from utils.dates import date_to_iso
+from utils.docx_parser import extract_docx_text, parse_docx as parse_docx_legacy
+from utils.normalize_phones import normalize_phone
+from utils.openai_extractor import extract_participants as extract_participants_openai
+from utils.names import _to_app_display_name
+
+
+@dataclass
+class ComparisonResult:
+    extracted: dict[str, Any]
+    existing: dict[str, Any] | None
+    score: float
+
+
+class DocxImportService:
+    """Extract and persist participants from uploaded DOCX files."""
+
+    def __init__(self) -> None:
+        self.participant_repo = ParticipantRepository()
+        self.participant_event_repo = ParticipantEventRepository()
+
+    def extract_participants(self, files: list[str], eid: str) -> dict[str, Any]:
+        participants: list[dict[str, Any]] = []
+        for path in files:
+            for extracted in self.parse_docx(path):
+                normalized = self.normalize_fields(extracted)
+                participant_json = self.convert_to_participant_json(normalized)
+                participant_json["_source_file"] = os.path.basename(path)
+                participant_json["_eid"] = eid
+                participants.append(participant_json)
+
+        return {"participants": participants, "eid": eid}
+
+    def parse_docx(self, file_path: str) -> list[dict[str, Any]]:
+        text = extract_docx_text(file_path)
+        if text:
+            try:
+                extracted = extract_participants_openai(text)
+            except Exception:
+                extracted = []
+            if extracted:
+                return extracted
+
+        return parse_docx_legacy(file_path)
+
+    def normalize_fields(self, data: dict[str, Any]) -> dict[str, Any]:
+        normalized = dict(data)
+        country_value = str(normalized.get("representing_country", ""))
+        if country_value:
+            resolved = resolve_country_flexible(country_value)
+            normalized["representing_country"] = resolved.get("cid", "") if resolved else ""
+
+        birth_country = str(normalized.get("birth_country", ""))
+        if birth_country:
+            resolved = resolve_country_flexible(birth_country)
+            normalized["birth_country"] = resolved.get("cid", "") if resolved else ""
+
+        if not normalized.get("birth_country") and normalized.get("representing_country"):
+            normalized["birth_country"] = normalized.get("representing_country", "")
+
+        citizenships = normalized.get("citizenships") or []
+        if isinstance(citizenships, str):
+            citizenships = [citizenships]
+        if not citizenships and normalized.get("representing_country"):
+            citizenships = [normalized["representing_country"]]
+        normalized["citizenships"] = [
+            resolve_country_flexible(value).get("cid")
+            for value in citizenships
+            if value and resolve_country_flexible(value)
+        ] or ([normalized["representing_country"]] if normalized.get("representing_country") else [])
+
+        if normalized.get("name"):
+            normalized["name"] = _to_app_display_name(str(normalized["name"]))
+
+        if normalized.get("dob"):
+            normalized["dob"] = date_to_iso(normalized.get("dob")) or str(normalized.get("dob", ""))
+
+        phone_value = normalized.get("phone")
+        if phone_value:
+            normalized["phone"] = normalize_phone(str(phone_value)) or str(phone_value)
+
+        return normalized
+
+    def convert_to_participant_json(self, data: dict[str, Any]) -> dict[str, Any]:
+        defaults = {
+            "pid": "",
+            "name": "",
+            "representing_country": "",
+            "transportation": "",
+            "transport_other": "",
+            "traveling_from": "",
+            "returning_to": "",
+            "grade": 1,
+            "position": "",
+            "phone": "",
+            "email": "",
+            "gender": "",
+            "dob": "",
+            "pob": "",
+            "birth_country": "",
+            "citizenships": [],
+            "travel_doc_type": "",
+            "travel_doc_number": "",
+            "travel_doc_issue_date": "",
+            "travel_doc_expiry_date": "",
+            "travel_doc_issued_by": "",
+            "diet_restrictions": "",
+            "organization": "",
+            "unit": "",
+            "rank": "",
+            "intl_authority": "",
+            "bio_short": "",
+            "bank_name": "",
+            "iban": "",
+            "iban_type": "",
+            "swift": "",
+        }
+        payload = dict(defaults)
+        payload.update({k: v for k, v in data.items() if k in defaults})
+        return payload
+
+    def compare_with_db(self, participant: dict[str, Any]) -> ComparisonResult:
+        # strict candidate set by country + dob, then fuzzy on normalized name
+        country = participant.get("representing_country")
+        desired_dob = participant.get("dob")
+        extracted_name = _to_app_display_name(participant.get("name", ""))
+        candidates = self.participant_repo.find_by_country(country) if country else []
+
+        best = None
+        best_score = 0.0
+        for candidate in candidates:
+            if desired_dob and candidate.dob:
+                candidate_dob = candidate.dob.date().isoformat()
+                if candidate_dob != desired_dob:
+                    continue
+            score = SequenceMatcher(None, extracted_name.lower(), candidate.name.lower()).ratio()
+            if score > best_score:
+                best_score = score
+                best = candidate
+
+        existing_payload = best.to_mongo() if best and best_score >= 0.78 else None
+        return ComparisonResult(extracted=participant, existing=existing_payload, score=best_score)
+
+    def save_participant(self, participant: dict[str, Any], eid: str) -> str:
+        comparison = self.compare_with_db(participant)
+        if comparison.existing:
+            pid = comparison.existing["pid"]
+            update_payload = {
+                key: value
+                for key, value in participant.items()
+                if key in comparison.existing and value not in (None, "")
+            }
+            update_payload.pop("pid", None)
+            self.participant_repo.update(pid, update_payload)
+        else:
+            pid = self.participant_repo.generate_next_pid()
+            model_payload = dict(participant)
+            model_payload.update({"pid": pid, "grade": 1, "gender": participant.get("gender") or "Male"})
+            from domain.models.participant import Participant
+
+            participant_model = Participant.model_validate(model_payload, context={"allow_missing_dob": True})
+            self.participant_repo.save(participant_model)
+
+        self.participant_event_repo.ensure_link(participant_id=pid, event_id=eid)
+        return pid

--- a/templates/base.html
+++ b/templates/base.html
@@ -27,9 +27,18 @@
             <a class="nav-link{% if request.endpoint and request.endpoint.startswith('events.') %} active{% endif %}"
              href="{{ url_for('events.show_events') }}">Events</a>
         </li>
-        <li class="nav-item">
-            <a class="nav-link{% if request.endpoint and request.endpoint.startswith('imports.') %} active{% endif %}"
-             href="{{ url_for('imports.upload_form') }}">Import</a>
+        <li class="nav-item dropdown">
+            {% set import_active = request.endpoint and (request.endpoint.startswith('imports.') or request.endpoint.startswith('docx_upload.')) %}
+            <a class="nav-link dropdown-toggle{% if import_active %} active{% endif %}" href="#" role="button"
+               data-bs-toggle="dropdown" aria-expanded="false">
+              Import
+            </a>
+            <ul class="dropdown-menu">
+              <li><a class="dropdown-item{% if request.endpoint and request.endpoint.startswith('imports.') %} active{% endif %}"
+                     href="{{ url_for('imports.upload_form') }}">Event</a></li>
+              <li><a class="dropdown-item{% if request.endpoint and request.endpoint.startswith('docx_upload.') %} active{% endif %}"
+                     href="{{ url_for('docx_upload.upload_docx') }}">Docx</a></li>
+            </ul>
         </li>
       </ul>
 

--- a/templates/docx_review.html
+++ b/templates/docx_review.html
@@ -1,0 +1,126 @@
+{% extends "base.html" %}
+{% block title %}DOCX Bulk Upload{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <div>
+    <h1 class="h3 mb-1">Bulk DOCX Upload</h1>
+    <p class="text-muted mb-0">Upload participant registration Word files, review extraction, and confirm DB updates.</p>
+  </div>
+</div>
+
+{% if stage == 'review' %}
+<form method="post" action="{{ url_for('docx_upload.compare_docx') }}" id="reviewForm">
+  <input type="hidden" name="eid" value="{{ eid }}">
+  <input type="hidden" name="participants_json" id="participantsJson">
+  <div class="alert alert-info">Review extracted entries. You can edit inline before comparison.</div>
+  {% for participant in participants %}
+  <div class="card mb-3 participant-card" data-index="{{ loop.index0 }}">
+    <div class="card-header d-flex justify-content-between">
+      <strong>{{ participant.name or 'Unnamed participant' }}</strong>
+      <span class="badge text-bg-secondary">{{ participant._source_file }}</span>
+    </div>
+    <div class="card-body">
+      <div class="row g-2">
+        {% for key, value in participant.items() if not key.startswith('_') %}
+        <div class="col-md-4">
+          <label class="form-label small">{{ key }}</label>
+          <input class="form-control form-control-sm field-input" data-field="{{ key }}" value="{{ value if value is not iterable or value is string else value|join(',') }}">
+        </div>
+        {% endfor %}
+      </div>
+      <div class="form-check mt-2">
+        <input class="form-check-input skip-check" type="checkbox" id="skip_{{ loop.index0 }}">
+        <label class="form-check-label" for="skip_{{ loop.index0 }}">Skip this participant</label>
+      </div>
+    </div>
+  </div>
+  {% endfor %}
+  <button class="btn btn-primary" type="submit">Compare with database</button>
+</form>
+{% endif %}
+
+{% if stage == 'compare' %}
+<form method="post" action="{{ url_for('docx_upload.commit_docx') }}" id="compareForm">
+  <input type="hidden" name="eid" value="{{ eid }}">
+  <input type="hidden" name="participants_json" id="commitParticipantsJson">
+  {% for item in compared %}
+  {% set outer_index = loop.index0 %}
+  <div class="card mb-3 comparison-card" data-index="{{ outer_index }}">
+    <div class="card-header">
+      <strong>{{ item.extracted.name }}</strong>
+      {% if item.existing %}
+      <span class="badge text-bg-warning">Matched ({{ '%.2f'|format(item.score) }})</span>
+      {% else %}
+      <span class="badge text-bg-success">New participant</span>
+      {% endif %}
+    </div>
+    <div class="card-body">
+      <table class="table table-sm align-middle">
+        <thead><tr><th>Field</th><th>Database</th><th>Extracted</th><th>Choice</th></tr></thead>
+        <tbody>
+          {% for key, value in item.extracted.items() if not key.startswith('_') %}
+          <tr data-field="{{ key }}" data-extracted="{{ value }}" data-existing="{{ item.existing.get(key, '') if item.existing else '' }}">
+            <td>{{ key }}</td>
+            <td>{{ item.existing.get(key, '') if item.existing else '' }}</td>
+            <td>{{ value }}</td>
+            <td>
+              {% if item.existing %}
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="choice_{{ outer_index }}_{{ key }}" value="existing" checked>
+                <label class="form-check-label">Keep DB</label>
+              </div>
+              {% endif %}
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="choice_{{ outer_index }}_{{ key }}" value="extracted" {% if not item.existing %}checked{% endif %}>
+                <label class="form-check-label">Use extracted</label>
+              </div>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {% endfor %}
+  <button class="btn btn-success" type="submit">Confirm and save</button>
+</form>
+{% endif %}
+
+<script>
+  function serializeReview() {
+    const cards = document.querySelectorAll('.participant-card');
+    const result = [];
+    cards.forEach(card => {
+      const payload = {};
+      card.querySelectorAll('.field-input').forEach(input => {
+        payload[input.dataset.field] = input.value;
+      });
+      payload._skip = card.querySelector('.skip-check')?.checked || false;
+      result.push(payload);
+    });
+    const hidden = document.getElementById('participantsJson');
+    if (hidden) hidden.value = JSON.stringify(result);
+  }
+
+  function serializeCompare() {
+    const cards = document.querySelectorAll('.comparison-card');
+    const participants = [];
+    cards.forEach((card, cardIndex) => {
+      const payload = {};
+      card.querySelectorAll('tr[data-field]').forEach(row => {
+        const field = row.dataset.field;
+        const extracted = row.dataset.extracted;
+        const existing = row.dataset.existing;
+        const selected = row.querySelector('input:checked');
+        payload[field] = selected && selected.value === 'existing' ? existing : extracted;
+      });
+      participants.push(payload);
+    });
+    const hidden = document.getElementById('commitParticipantsJson');
+    if (hidden) hidden.value = JSON.stringify(participants);
+  }
+
+  document.getElementById('reviewForm')?.addEventListener('submit', serializeReview);
+  document.getElementById('compareForm')?.addEventListener('submit', serializeCompare);
+</script>
+{% endblock %}

--- a/templates/docx_review.html
+++ b/templates/docx_review.html
@@ -8,6 +8,17 @@
   </div>
 </div>
 
+{% if warnings %}
+<div class="alert alert-warning">
+  <strong>Extraction diagnostics:</strong>
+  <ul class="mb-0 mt-2">
+    {% for warning in warnings %}
+    <li>{{ warning }}</li>
+    {% endfor %}
+  </ul>
+</div>
+{% endif %}
+
 {% if stage == 'review' %}
 <form method="post" action="{{ url_for('docx_upload.compare_docx') }}" id="reviewForm">
   <input type="hidden" name="eid" value="{{ eid }}">
@@ -17,7 +28,10 @@
   <div class="card mb-3 participant-card" data-index="{{ loop.index0 }}">
     <div class="card-header d-flex justify-content-between">
       <strong>{{ participant.name or 'Unnamed participant' }}</strong>
-      <span class="badge text-bg-secondary">{{ participant._source_file }}</span>
+      <div class="d-flex gap-2">
+        <span class="badge text-bg-secondary">{{ participant._source_file }}</span>
+        <span class="badge {% if participant._extraction_engine == "openai" %}text-bg-success{% else %}text-bg-warning{% endif %}">{{ participant._extraction_engine|default("legacy")|upper }}</span>
+      </div>
     </div>
     <div class="card-body">
       <div class="row g-2">

--- a/templates/docx_upload.html
+++ b/templates/docx_upload.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block title %}DOCX Upload{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <div>
+    <h1 class="h3 mb-1">Bulk DOCX Upload</h1>
+    <p class="text-muted mb-0">Upload one or more registration Word files for extraction.</p>
+  </div>
+</div>
+
+<form method="post" enctype="multipart/form-data" class="card card-body">
+  <div class="row g-3">
+    <div class="col-md-4">
+      <label class="form-label" for="eid">Event ID (eid)</label>
+      <input class="form-control" id="eid" name="eid" placeholder="PFE25M1" required>
+    </div>
+    <div class="col-md-8">
+      <label class="form-label" for="files">DOCX files</label>
+      <input class="form-control" id="files" type="file" name="files" accept=".docx" multiple required>
+    </div>
+  </div>
+  <div class="mt-3">
+    <button class="btn btn-primary" type="submit">Extract participants</button>
+  </div>
+</form>
+{% endblock %}

--- a/tests/test_docx_import_service_extraction_mode.py
+++ b/tests/test_docx_import_service_extraction_mode.py
@@ -27,3 +27,54 @@ def test_extract_participants_sets_openai_engine(monkeypatch) -> None:
     assert bundle["warnings"] == []
     assert bundle["participants"][0]["_extraction_engine"] == "openai"
     assert bundle["participants"][0]["_source_file"] == "demo.docx"
+
+
+def test_save_participant_updates_event_snapshot(monkeypatch) -> None:
+    service = DocxImportService.__new__(DocxImportService)
+
+    class _DummyEventCollection:
+        def __init__(self) -> None:
+            self.calls = []
+
+        def update_one(self, query, payload):
+            self.calls.append((query, payload))
+
+    class _DummyEventRepo:
+        def __init__(self) -> None:
+            self.collection = _DummyEventCollection()
+            self.links = []
+
+        def ensure_link(self, participant_id: str, event_id: str):
+            self.links.append((participant_id, event_id))
+
+    class _DummyParticipantRepo:
+        def update(self, pid, payload):
+            self.last = (pid, payload)
+
+        def generate_next_pid(self):
+            return "P9999"
+
+        def save(self, _model):
+            return None
+
+    service.participant_event_repo = _DummyEventRepo()
+    service.participant_repo = _DummyParticipantRepo()
+
+    monkeypatch.setattr(service, "compare_with_db", lambda _p: type("R", (), {"existing": {"pid": "P0001"}})())
+
+    participant = {
+        "pid": "P0001",
+        "name": "John Doe",
+        "representing_country": "C001",
+        "transportation": "Air (Airplane)",
+        "travel_doc_type": "Passport",
+    }
+
+    pid = service.save_participant(participant, "E001")
+
+    assert pid == "P0001"
+    assert service.participant_event_repo.links == [("P0001", "E001")]
+    query, payload = service.participant_event_repo.collection.calls[0]
+    assert query == {"participant_id": "P0001", "event_id": "E001"}
+    assert payload["$set"]["transportation"] == "Air (Airplane)"
+    assert payload["$set"]["travel_doc_type"] == "Passport"

--- a/tests/test_docx_import_service_extraction_mode.py
+++ b/tests/test_docx_import_service_extraction_mode.py
@@ -1,0 +1,33 @@
+from services.docx_import_service import DocxImportService
+import services.docx_import_service as mod
+
+
+def test_parse_docx_falls_back_to_legacy_when_key_missing(monkeypatch) -> None:
+    service = DocxImportService.__new__(DocxImportService)
+
+    monkeypatch.setattr(mod, "extract_docx_text", lambda _path: "some text")
+    monkeypatch.setattr(mod, "_resolve_api_key", lambda: None)
+    monkeypatch.setattr(mod, "parse_docx_legacy", lambda _path: [{"name": "Legacy User"}])
+
+    participants, engine, warning = service.parse_docx("dummy.docx")
+
+    assert participants == [{"name": "Legacy User"}]
+    assert engine == "legacy"
+    assert warning and "not configured" in warning
+
+
+def test_extract_participants_sets_engine_and_collects_warnings(monkeypatch) -> None:
+    service = DocxImportService.__new__(DocxImportService)
+
+    monkeypatch.setattr(
+        service,
+        "parse_docx",
+        lambda _path: ([{"name": "John Doe", "representing_country": "", "citizenships": []}], "legacy", "fallback"),
+    )
+    monkeypatch.setattr(service, "normalize_fields", lambda row: row)
+
+    bundle = service.extract_participants(["/tmp/demo.docx"], "E001")
+
+    assert bundle["warnings"] == ["demo.docx: fallback"]
+    assert bundle["participants"][0]["_extraction_engine"] == "legacy"
+    assert bundle["participants"][0]["_source_file"] == "demo.docx"

--- a/tests/test_docx_import_service_extraction_mode.py
+++ b/tests/test_docx_import_service_extraction_mode.py
@@ -2,32 +2,28 @@ from services.docx_import_service import DocxImportService
 import services.docx_import_service as mod
 
 
-def test_parse_docx_falls_back_to_legacy_when_key_missing(monkeypatch) -> None:
+def test_parse_docx_raises_when_key_missing(monkeypatch) -> None:
     service = DocxImportService.__new__(DocxImportService)
 
     monkeypatch.setattr(mod, "extract_docx_text", lambda _path: "some text")
     monkeypatch.setattr(mod, "_resolve_api_key", lambda: None)
-    monkeypatch.setattr(mod, "parse_docx_legacy", lambda _path: [{"name": "Legacy User"}])
 
-    participants, engine, warning = service.parse_docx("dummy.docx")
+    try:
+        service.parse_docx("dummy.docx")
+    except RuntimeError as exc:
+        assert "OPENAIAPI" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("Expected RuntimeError when API key is missing")
 
-    assert participants == [{"name": "Legacy User"}]
-    assert engine == "legacy"
-    assert warning and "not configured" in warning
 
-
-def test_extract_participants_sets_engine_and_collects_warnings(monkeypatch) -> None:
+def test_extract_participants_sets_openai_engine(monkeypatch) -> None:
     service = DocxImportService.__new__(DocxImportService)
 
-    monkeypatch.setattr(
-        service,
-        "parse_docx",
-        lambda _path: ([{"name": "John Doe", "representing_country": "", "citizenships": []}], "legacy", "fallback"),
-    )
+    monkeypatch.setattr(service, "parse_docx", lambda _path: [{"name": "John Doe", "representing_country": "", "citizenships": []}])
     monkeypatch.setattr(service, "normalize_fields", lambda row: row)
 
     bundle = service.extract_participants(["/tmp/demo.docx"], "E001")
 
-    assert bundle["warnings"] == ["demo.docx: fallback"]
-    assert bundle["participants"][0]["_extraction_engine"] == "legacy"
+    assert bundle["warnings"] == []
+    assert bundle["participants"][0]["_extraction_engine"] == "openai"
     assert bundle["participants"][0]["_source_file"] == "demo.docx"

--- a/tests/test_docx_import_service_fields.py
+++ b/tests/test_docx_import_service_fields.py
@@ -27,31 +27,50 @@ def test_convert_to_participant_json_matches_participant_collection_shape() -> N
         "rank": "Investigator",
         "intl_authority": True,
         "bio_short": "bio",
-        # participant_event-only fields should not be present in participant payload
         "transportation": "Air (Airplane)",
-        "transport_other": "",
-        "traveling_from": "Tirana",
-        "returning_to": "Tirana",
         "travel_doc_type": "Passport",
-        "travel_doc_number": "BD7178397",
-        "travel_doc_issue_date": "2022-05-24",
-        "travel_doc_expiry_date": "2032-05-23",
-        "travel_doc_issued_by": "MPB",
     }
 
-    payload = service.convert_to_participant_json(source)
+    participant_payload = service.convert_to_participant_json(source)
+    event_payload = service.convert_to_participant_event_json(source)
 
-    assert payload["pid"] == "P0873"
-    assert payload["name"] == "Mario XHAJA"
-    assert payload["intl_authority"] is True
-    assert payload["organization"] == "LEVER"
+    assert participant_payload["pid"] == "P0873"
+    assert participant_payload["name"] == "Mario XHAJA"
+    assert participant_payload["intl_authority"] is True
+    assert participant_payload["organization"] == "LEVER"
 
-    assert "_id" not in payload
-    assert "created_at" not in payload
-    assert "updated_at" not in payload
-    assert "_audit" not in payload
+    assert "_id" not in participant_payload
+    assert "created_at" not in participant_payload
+    assert "updated_at" not in participant_payload
+    assert "_audit" not in participant_payload
 
-    assert "transportation" not in payload
-    assert "travel_doc_type" not in payload
-    assert "travel_doc_number" not in payload
-    assert "traveling_from" not in payload
+    # participant_event fields are kept separately, not dropped
+    assert "transportation" not in participant_payload
+    assert event_payload["transportation"] == "Air (Airplane)"
+    assert event_payload["travel_doc_type"] == "Passport"
+
+
+def test_extract_participants_merges_participant_and_participant_event_fields(monkeypatch) -> None:
+    service = DocxImportService.__new__(DocxImportService)
+
+    monkeypatch.setattr(
+        service,
+        "parse_docx",
+        lambda _path: [
+            {
+                "name": "Mario XHAJA",
+                "representing_country": "C002",
+                "transportation": "Air (Airplane)",
+                "travel_doc_type": "Passport",
+                "citizenships": ["C002"],
+            }
+        ],
+    )
+    monkeypatch.setattr(service, "normalize_fields", lambda row: row)
+
+    bundle = service.extract_participants(["/tmp/mario.docx"], "E001")
+
+    row = bundle["participants"][0]
+    assert row["name"] == "Mario XHAJA"
+    assert row["transportation"] == "Air (Airplane)"
+    assert row["travel_doc_type"] == "Passport"

--- a/tests/test_docx_import_service_fields.py
+++ b/tests/test_docx_import_service_fields.py
@@ -1,16 +1,17 @@
 from services.docx_import_service import DocxImportService
 
 
-def test_convert_to_participant_json_keeps_extended_form_fields() -> None:
+def test_convert_to_participant_json_matches_participant_collection_shape() -> None:
     service = DocxImportService.__new__(DocxImportService)
 
     source = {
+        "_id": "mongo-generated",
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-01-01T00:00:00Z",
+        "_audit": [{"x": 1}],
         "pid": "P0873",
         "name": "Mario XHAJA",
         "representing_country": "C002",
-        "transportation": "Air (Airplane)",
-        "transport_other": "",
-        "traveling_from": "Tirana",
         "grade": 1,
         "position": "NBI Investigator",
         "phone": "+355684612950",
@@ -20,32 +21,37 @@ def test_convert_to_participant_json_keeps_extended_form_fields() -> None:
         "pob": "Memmingen",
         "birth_country": "C083",
         "citizenships": ["C002"],
-        "travel_doc_type": "Passport",
-        "travel_doc_number": "BD7178397",
-        "travel_doc_issue_date": "2022-05-24",
-        "travel_doc_expiry_date": "2032-05-23",
-        "travel_doc_issued_by": "MPB",
-        "returning_to": "Tirana",
         "diet_restrictions": "No Pork, No Alcohol",
         "organization": "LEVER",
         "unit": "NBI",
         "rank": "Investigator",
         "intl_authority": True,
         "bio_short": "bio",
-        "bank_name": "Credins Bank",
-        "iban": "AL51212110090000000001900345",
-        "iban_type": "USD",
-        "swift": "CDISALTR",
-        "ignored": "value",
+        # participant_event-only fields should not be present in participant payload
+        "transportation": "Air (Airplane)",
+        "transport_other": "",
+        "traveling_from": "Tirana",
+        "returning_to": "Tirana",
+        "travel_doc_type": "Passport",
+        "travel_doc_number": "BD7178397",
+        "travel_doc_issue_date": "2022-05-24",
+        "travel_doc_expiry_date": "2032-05-23",
+        "travel_doc_issued_by": "MPB",
     }
 
     payload = service.convert_to_participant_json(source)
 
-    assert payload["travel_doc_type"] == "Passport"
-    assert payload["transport_other"] == ""
-    assert payload["traveling_from"] == "Tirana"
-    assert payload["returning_to"] == "Tirana"
-    assert payload["unit"] == "NBI"
-    assert payload["intl_authority"] is True
     assert payload["pid"] == "P0873"
-    assert "ignored" not in payload
+    assert payload["name"] == "Mario XHAJA"
+    assert payload["intl_authority"] is True
+    assert payload["organization"] == "LEVER"
+
+    assert "_id" not in payload
+    assert "created_at" not in payload
+    assert "updated_at" not in payload
+    assert "_audit" not in payload
+
+    assert "transportation" not in payload
+    assert "travel_doc_type" not in payload
+    assert "travel_doc_number" not in payload
+    assert "traveling_from" not in payload

--- a/tests/test_docx_import_service_fields.py
+++ b/tests/test_docx_import_service_fields.py
@@ -1,0 +1,51 @@
+from services.docx_import_service import DocxImportService
+
+
+def test_convert_to_participant_json_keeps_extended_form_fields() -> None:
+    service = DocxImportService.__new__(DocxImportService)
+
+    source = {
+        "pid": "P0873",
+        "name": "Mario XHAJA",
+        "representing_country": "C002",
+        "transportation": "Air (Airplane)",
+        "transport_other": "",
+        "traveling_from": "Tirana",
+        "grade": 1,
+        "position": "NBI Investigator",
+        "phone": "+355684612950",
+        "email": "mario.xhaja@spak.gov.al",
+        "gender": "Male",
+        "dob": "1993-12-11",
+        "pob": "Memmingen",
+        "birth_country": "C083",
+        "citizenships": ["C002"],
+        "travel_doc_type": "Passport",
+        "travel_doc_number": "BD7178397",
+        "travel_doc_issue_date": "2022-05-24",
+        "travel_doc_expiry_date": "2032-05-23",
+        "travel_doc_issued_by": "MPB",
+        "returning_to": "Tirana",
+        "diet_restrictions": "No Pork, No Alcohol",
+        "organization": "LEVER",
+        "unit": "NBI",
+        "rank": "Investigator",
+        "intl_authority": True,
+        "bio_short": "bio",
+        "bank_name": "Credins Bank",
+        "iban": "AL51212110090000000001900345",
+        "iban_type": "USD",
+        "swift": "CDISALTR",
+        "ignored": "value",
+    }
+
+    payload = service.convert_to_participant_json(source)
+
+    assert payload["travel_doc_type"] == "Passport"
+    assert payload["transport_other"] == ""
+    assert payload["traveling_from"] == "Tirana"
+    assert payload["returning_to"] == "Tirana"
+    assert payload["unit"] == "NBI"
+    assert payload["intl_authority"] is True
+    assert payload["pid"] == "P0873"
+    assert "ignored" not in payload

--- a/tests/test_docx_parser.py
+++ b/tests/test_docx_parser.py
@@ -1,0 +1,40 @@
+from docx import Document
+
+from utils.docx_parser import parse_docx
+
+
+def test_parse_docx_pattern_1(tmp_path):
+    file_path = tmp_path / "form.docx"
+    doc = Document()
+    table = doc.add_table(rows=2, cols=4)
+    table.cell(0, 0).text = "NAME & LAST NAME"
+    table.cell(0, 1).text = "Dragan Mektic"
+    table.cell(0, 2).text = "DOB"
+    table.cell(0, 3).text = "Dec/24/1956"
+    table.cell(1, 0).text = "GENDER"
+    table.cell(1, 1).text = "Male"
+    table.cell(1, 2).text = "COUNTRY"
+    table.cell(1, 3).text = "BiH"
+    doc.save(file_path)
+
+    participants = parse_docx(str(file_path))
+
+    assert len(participants) == 1
+    assert participants[0]["name"] == "Dragan Mektic"
+    assert participants[0]["dob"] == "1956-12-24"
+    assert participants[0]["gender"] == "Male"
+
+
+def test_parse_docx_pattern_3(tmp_path):
+    file_path = tmp_path / "list.docx"
+    doc = Document()
+    doc.add_paragraph("4. Makedonija")
+    doc.add_paragraph("1. Dragi ZLATANOVSKI (13. 2. 1965.)")
+    doc.save(file_path)
+
+    participants = parse_docx(str(file_path))
+
+    assert len(participants) == 1
+    assert participants[0]["name"] == "Dragi ZLATANOVSKI"
+    assert participants[0]["dob"] == "1965-02-13"
+    assert participants[0]["representing_country"] == "Makedonija"

--- a/tests/test_docx_review_template.py
+++ b/tests/test_docx_review_template.py
@@ -1,0 +1,38 @@
+from flask import Flask, render_template
+from pathlib import Path
+
+
+def _build_app() -> Flask:
+    root = Path(__file__).resolve().parents[1]
+    app = Flask(__name__, template_folder=str(root / "templates"), static_folder=str(root / "static"))
+    app.secret_key = "test"
+
+    app.add_url_rule("/home", endpoint="main.show_home", view_func=lambda: "home")
+    app.add_url_rule("/participants", endpoint="participants.show_participants", view_func=lambda: "participants")
+    app.add_url_rule("/events", endpoint="events.show_events", view_func=lambda: "events")
+    app.add_url_rule("/imports", endpoint="imports.upload_form", view_func=lambda: "imports")
+    app.add_url_rule("/docx", endpoint="docx_upload.upload_docx", view_func=lambda: "docx")
+    app.add_url_rule("/docx/commit", endpoint="docx_upload.commit_docx", view_func=lambda: "commit", methods=["POST"])
+    app.add_url_rule("/docx/compare", endpoint="docx_upload.compare_docx", view_func=lambda: "compare", methods=["POST"])
+    app.add_url_rule("/login", endpoint="auth.login", view_func=lambda: "login")
+    app.add_url_rule("/logout", endpoint="auth.logout", view_func=lambda: "logout", methods=["POST"])
+
+    return app
+
+
+def test_docx_compare_template_renders_without_loop_parent_error() -> None:
+    app = _build_app()
+    compared = [
+        {
+            "extracted": {"name": "Alice Doe", "email": "alice@example.com"},
+            "existing": {"name": "Alice Doe", "email": "old@example.com"},
+            "score": 0.93,
+        }
+    ]
+
+    with app.test_request_context("/docx"):
+        html = render_template("docx_review.html", stage="compare", compared=compared, eid="E001")
+
+    assert "choice_0_name" in html
+    assert "choice_0_email" in html
+    assert "Matched (0.93)" in html

--- a/tests/test_openai_extractor.py
+++ b/tests/test_openai_extractor.py
@@ -68,3 +68,30 @@ def test_resolve_api_key_prefers_openaiapi_then_openai(monkeypatch) -> None:
     assert _resolve_api_key() == "primary-key"
 
     assert _resolve_api_key("explicit") == "explicit"
+
+
+def test_openai_extractor_raises_detailed_runtime_error() -> None:
+    class _Boom(Exception):
+        def __init__(self) -> None:
+            super().__init__("server exploded")
+            self.status_code = 500
+            self.request_id = "req_123"
+            self.body = {"error": "boom"}
+
+    class _FailResponses:
+        def create(self, **_kwargs):
+            raise _Boom()
+
+    class _FailClient:
+        responses = _FailResponses()
+
+    try:
+        extract_participants("text", client=_FailClient())
+    except RuntimeError as exc:
+        message = str(exc)
+        assert "OpenAI responses.create failed" in message
+        assert "status_code=500" in message
+        assert "request_id=req_123" in message
+        assert "traceback=" in message
+    else:  # pragma: no cover - defensive
+        raise AssertionError("Expected RuntimeError")

--- a/tests/test_openai_extractor.py
+++ b/tests/test_openai_extractor.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from utils.docx_parser import extract_docx_text
+from utils.openai_extractor import _resolve_api_key, extract_participants
+from docx import Document
+
+
+class _FakeResponses:
+    def __init__(self, output_text: str) -> None:
+        self._output_text = output_text
+
+    def create(self, **_kwargs):
+        class _Resp:
+            def __init__(self, output_text: str) -> None:
+                self.output_text = output_text
+
+        return _Resp(self._output_text)
+
+
+class _FakeClient:
+    def __init__(self, output_text: str) -> None:
+        self.responses = _FakeResponses(output_text)
+
+
+def test_openai_extractor_parses_json_fence() -> None:
+    client = _FakeClient(
+        """```json
+{"participants":[{"name":"Jane Doe","citizenships":"C001"}]}
+```"""
+    )
+
+    participants = extract_participants("sample text", client=client)
+
+    assert len(participants) == 1
+    assert participants[0]["name"] == "Jane Doe"
+    assert participants[0]["citizenships"] == ["C001"]
+
+
+def test_extract_docx_text_reads_paragraphs_and_table(tmp_path) -> None:
+    file_path = tmp_path / "sample.docx"
+    doc = Document()
+    doc.add_paragraph("Header")
+    table = doc.add_table(rows=1, cols=2)
+    table.cell(0, 0).text = "NAME"
+    table.cell(0, 1).text = "John Doe"
+    doc.save(file_path)
+
+    text = extract_docx_text(str(file_path))
+
+    assert "Header" in text
+    assert "NAME" in text
+    assert "John Doe" in text
+
+
+def test_resolve_api_key_prefers_openai_then_custom(monkeypatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("extractionProjectAPI", raising=False)
+    monkeypatch.delenv("EXTRACTION_PROJECT_API", raising=False)
+
+    monkeypatch.setenv("extractionProjectAPI", "custom-key")
+    assert _resolve_api_key() == "custom-key"
+
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    assert _resolve_api_key() == "openai-key"
+
+    assert _resolve_api_key("explicit") == "explicit"

--- a/tests/test_openai_extractor.py
+++ b/tests/test_openai_extractor.py
@@ -52,7 +52,8 @@ def test_extract_docx_text_reads_paragraphs_and_table(tmp_path) -> None:
     assert "John Doe" in text
 
 
-def test_resolve_api_key_prefers_openai_then_custom(monkeypatch) -> None:
+def test_resolve_api_key_prefers_openaiapi_then_openai(monkeypatch) -> None:
+    monkeypatch.delenv("OPENAIAPI", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("extractionProjectAPI", raising=False)
     monkeypatch.delenv("EXTRACTION_PROJECT_API", raising=False)
@@ -62,5 +63,8 @@ def test_resolve_api_key_prefers_openai_then_custom(monkeypatch) -> None:
 
     monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
     assert _resolve_api_key() == "openai-key"
+
+    monkeypatch.setenv("OPENAIAPI", "primary-key")
+    assert _resolve_api_key() == "primary-key"
 
     assert _resolve_api_key("explicit") == "explicit"

--- a/utils/docx_parser.py
+++ b/utils/docx_parser.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any
+
+from docx import Document
+
+_LABEL_ALIASES = {
+    "country": "representing_country",
+    "name & last name": "name",
+    "name": "name",
+    "name last name": "name",
+    "dob": "dob",
+    "date of birth": "dob",
+    "pob": "pob",
+    "place of birth": "pob",
+    "passport number": "travel_doc_number",
+    "gender": "gender",
+    "diet restrictions": "diet_restrictions",
+    "institution": "organization",
+    "institution/organization": "organization",
+    "organization": "organization",
+    "position": "position",
+    "rank": "rank",
+    "phone": "phone",
+    "email": "email",
+    "transportation": "transportation",
+    "arrival": "arrival",
+    "departure": "departure",
+    "short professional biography": "bio_short",
+}
+
+_DATE_FORMATS = [
+    "%B/%d/%Y",
+    "%b/%d/%Y",
+    "%m/%d/%Y",
+    "%m/%d/%y",
+    "%d/%m/%Y",
+    "%d.%m.%Y",
+    "%d. %m. %Y",
+]
+
+
+def _clean(text: str) -> str:
+    return re.sub(r"\s+", " ", (text or "").replace("\xa0", " ")).strip()
+
+
+def _normalize_label(label: str) -> str:
+    normalized = re.sub(r"\s+", " ", label.lower()).strip(" :")
+    return _LABEL_ALIASES.get(normalized, normalized.replace(" ", "_"))
+
+
+def _normalize_date(raw: str) -> str:
+    value = _clean(raw).strip("./")
+    if not value:
+        return ""
+
+    value = value.replace("-", "/")
+    value = re.sub(r"\s+", "", value)
+
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.strptime(value, fmt).strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+
+    # Serbian/Croatian style: 13. 2. 1965.
+    m = re.match(r"^(\d{1,2})\.?[./](\d{1,2})\.?[./](\d{2,4})\.?$", value)
+    if m:
+        day, month, year = m.groups()
+        year = year if len(year) == 4 else f"19{year}"
+        try:
+            return datetime(int(year), int(month), int(day)).strftime("%Y-%m-%d")
+        except ValueError:
+            return ""
+    return ""
+
+
+def _normalize_gender(raw: str) -> str:
+    text = _clean(raw).lower()
+    if text in {"f", "female", "famele"}:
+        return "Female"
+    if text in {"m", "male"}:
+        return "Male"
+    return ""
+
+
+def _normalize_bool(raw: str) -> bool | str:
+    text = _clean(raw).lower()
+    if text in {"no", "n"}:
+        return False
+    if text in {"yes", "y"}:
+        return True
+    return ""
+
+
+def _extract_pattern_1(doc: Document) -> list[dict[str, Any]]:
+    participants: list[dict[str, Any]] = []
+    for table in doc.tables:
+        fields: dict[str, Any] = {}
+        for row in table.rows:
+            cells = [_clean(cell.text) for cell in row.cells if _clean(cell.text)]
+            if len(cells) < 2:
+                continue
+            i = 0
+            while i + 1 < len(cells):
+                key = _normalize_label(cells[i])
+                fields[key] = cells[i + 1]
+                i += 2
+
+        if fields.get("name"):
+            participants.append(fields)
+    return participants
+
+
+def _extract_pattern_2(lines: list[str]) -> list[dict[str, Any]]:
+    participants: list[dict[str, Any]] = []
+    date_pattern = re.compile(r"(\d{1,2}[/.]\d{1,2}[/.]\d{2,4})")
+
+    for line in lines:
+        if not date_pattern.search(line):
+            continue
+        parts = re.split(r"\t+|\s{2,}", line)
+        if len(parts) < 3:
+            continue
+
+        name = _clean(parts[0])
+        dob_match = date_pattern.search(line)
+        if not name or not dob_match:
+            continue
+
+        rank = _clean(parts[2]) if len(parts) > 2 else ""
+        tail = _clean(parts[3]) if len(parts) > 3 else ""
+        position, _, organization = tail.partition(",")
+        if "/" in position and not organization:
+            position, _, organization = position.partition("/")
+
+        participants.append(
+            {
+                "name": name,
+                "dob": dob_match.group(1),
+                "rank": rank,
+                "position": _clean(position),
+                "organization": _clean(organization),
+            }
+        )
+
+    return participants
+
+
+def _extract_pattern_3(lines: list[str]) -> list[dict[str, Any]]:
+    participants: list[dict[str, Any]] = []
+    country = ""
+    country_header = re.compile(r"^\d+\.\s+(.+)$")
+    list_item = re.compile(r"^\d+\.\s+([A-Za-zČĆŽŠĐčćžšđ\-\s]+)(?:\(|$)")
+
+    for line in lines:
+        header_match = country_header.match(line)
+        has_date = bool(re.search(r"\d{1,2}[./]\s*\d{1,2}[./]", line))
+        if header_match and len(header_match.group(1).split()) <= 4 and not has_date:
+            country = _clean(header_match.group(1))
+            continue
+
+        m = list_item.match(line)
+        if not m:
+            continue
+
+        name = _clean(m.group(1))
+        if not name:
+            continue
+
+        dob_match = re.search(r"\(([^)]+)\)", line)
+        participants.append(
+            {
+                "name": name,
+                "dob": dob_match.group(1) if dob_match else "",
+                "representing_country": country,
+            }
+        )
+    return participants
+
+
+def extract_docx_text(path: str, *, max_length: int = 12000) -> str:
+    """Extract plain text from DOCX paragraphs and tables for LLM parsing."""
+
+    doc = Document(path)
+    lines: list[str] = []
+
+    for paragraph in doc.paragraphs:
+        text = _clean(paragraph.text)
+        if text:
+            lines.append(text)
+
+    for table in doc.tables:
+        for row in table.rows:
+            for cell in row.cells:
+                text = _clean(cell.text)
+                if text:
+                    lines.append(text)
+
+    return "\n".join(lines)[:max_length]
+
+
+def parse_docx(path: str) -> list[dict[str, Any]]:
+    """Parse a DOCX file and return best-effort participant dictionaries."""
+
+    doc = Document(path)
+    lines = [_clean(p.text) for p in doc.paragraphs if _clean(p.text)]
+
+    participants = _extract_pattern_1(doc)
+    if not participants:
+        participants = _extract_pattern_2(lines)
+    if not participants:
+        participants = _extract_pattern_3(lines)
+
+    normalized: list[dict[str, Any]] = []
+    for participant in participants:
+        item = dict(participant)
+        if "dob" in item:
+            item["dob"] = _normalize_date(str(item.get("dob", "")))
+        if "arrival" in item:
+            item["arrival"] = _normalize_date(str(item.get("arrival", "")))
+        if "departure" in item:
+            item["departure"] = _normalize_date(str(item.get("departure", "")))
+        if "gender" in item:
+            item["gender"] = _normalize_gender(str(item.get("gender", "")))
+        if "diet_restrictions" in item:
+            maybe_bool = _normalize_bool(str(item.get("diet_restrictions", "")))
+            if maybe_bool != "":
+                item["diet_restrictions"] = maybe_bool
+        normalized.append(item)
+
+    return normalized

--- a/utils/openai_extractor.py
+++ b/utils/openai_extractor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import traceback
 from typing import Any
 
 MODEL = os.getenv("OPENAI_EXTRACTION_MODEL", "gpt-realtime-mini")
@@ -100,6 +101,35 @@ def _extract_json_payload(raw_text: str) -> dict[str, Any] | list[Any]:
         raise
 
 
+def _format_openai_exception(exc: Exception) -> str:
+    details = [
+        f"type={type(exc).__name__}",
+        f"message={exc}",
+    ]
+
+    status_code = getattr(exc, "status_code", None)
+    if status_code is not None:
+        details.append(f"status_code={status_code}")
+
+    request_id = getattr(exc, "request_id", None)
+    if request_id:
+        details.append(f"request_id={request_id}")
+
+    response = getattr(exc, "response", None)
+    if response is not None:
+        details.append(f"response={response}")
+
+    body = getattr(exc, "body", None)
+    if body is not None:
+        details.append(f"body={body}")
+
+    tb = traceback.format_exc()
+    if tb:
+        details.append("traceback=\n" + tb)
+
+    return "OpenAI responses.create failed: " + " | ".join(details)
+
+
 def extract_participants(text: str, *, client=None, model: str = MODEL) -> list[dict[str, Any]]:
     """Extract participants from raw text using OpenAI responses API."""
 
@@ -107,11 +137,14 @@ def extract_participants(text: str, *, client=None, model: str = MODEL) -> list[
         return []
 
     resolved_client = client or _get_client()
-    response = resolved_client.responses.create(
-        model=model,
-        input=[{"role": "user", "content": _build_prompt(text)}],
-        temperature=0,
-    )
+    try:
+        response = resolved_client.responses.create(
+            model=model,
+            input=[{"role": "user", "content": _build_prompt(text)}],
+            temperature=0,
+        )
+    except Exception as exc:
+        raise RuntimeError(_format_openai_exception(exc)) from exc
     payload = _extract_json_payload(response.output_text)
 
     participants: list[dict[str, Any]]

--- a/utils/openai_extractor.py
+++ b/utils/openai_extractor.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+MODEL = os.getenv("OPENAI_EXTRACTION_MODEL", "gpt-4.1")
+MAX_LENGTH = 12000
+
+_PARTICIPANT_FIELDS = [
+    "name",
+    "representing_country",
+    "gender",
+    "dob",
+    "pob",
+    "birth_country",
+    "citizenships",
+    "position",
+    "organization",
+    "unit",
+    "rank",
+    "intl_authority",
+    "phone",
+    "email",
+    "diet_restrictions",
+    "bio_short",
+    "transportation",
+    "transport_other",
+    "traveling_from",
+    "returning_to",
+    "travel_doc_type",
+    "travel_doc_number",
+    "travel_doc_issue_date",
+    "travel_doc_expiry_date",
+    "travel_doc_issued_by",
+    "bank_name",
+    "iban",
+    "iban_type",
+    "swift",
+]
+
+
+def _build_prompt(document_text: str) -> str:
+    fields = "\n".join(_PARTICIPANT_FIELDS)
+    return (
+        "You are a document data extraction engine.\n"
+        "Extract participants from the provided document and return ONLY valid JSON.\n\n"
+        "Return a JSON object with key 'participants' and array values.\n"
+        "Each participant must contain these fields:\n"
+        f"{fields}\n\n"
+        "Rules:\n"
+        "- If missing, use empty string for scalar fields and [] for citizenships\n"
+        "- Date format must be YYYY-MM-DD\n"
+        "- Detect multiple participants and all supported languages\n"
+        "- Do not include markdown code fences\n\n"
+        f"DOCUMENT:\n{document_text[:MAX_LENGTH]}"
+    )
+
+
+def _resolve_api_key(explicit_key: str | None = None) -> str | None:
+    if explicit_key:
+        return explicit_key
+
+    return (
+        os.getenv("OPENAI_API_KEY")
+        or os.getenv("extractionProjectAPI")
+        or os.getenv("EXTRACTION_PROJECT_API")
+    )
+
+
+def _get_client(api_key: str | None = None):
+    from openai import OpenAI
+
+    return OpenAI(api_key=_resolve_api_key(api_key))
+
+
+def _extract_json_payload(raw_text: str) -> dict[str, Any] | list[Any]:
+    text = (raw_text or "").strip()
+    if not text:
+        return {"participants": []}
+
+    if text.startswith("```"):
+        text = text.strip("`")
+        text = text.replace("json\n", "", 1).strip()
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        start_obj = text.find("{")
+        end_obj = text.rfind("}")
+        if start_obj != -1 and end_obj != -1 and end_obj > start_obj:
+            return json.loads(text[start_obj : end_obj + 1])
+
+        start_arr = text.find("[")
+        end_arr = text.rfind("]")
+        if start_arr != -1 and end_arr != -1 and end_arr > start_arr:
+            return json.loads(text[start_arr : end_arr + 1])
+
+        raise
+
+
+def extract_participants(text: str, *, client=None, model: str = MODEL) -> list[dict[str, Any]]:
+    """Extract participants from raw text using OpenAI responses API."""
+
+    if not (text or "").strip():
+        return []
+
+    resolved_client = client or _get_client()
+    response = resolved_client.responses.create(
+        model=model,
+        input=[{"role": "user", "content": _build_prompt(text)}],
+        temperature=0,
+    )
+    payload = _extract_json_payload(response.output_text)
+
+    participants: list[dict[str, Any]]
+    if isinstance(payload, dict):
+        raw_participants = payload.get("participants") or []
+        participants = [entry for entry in raw_participants if isinstance(entry, dict)]
+    elif isinstance(payload, list):
+        participants = [entry for entry in payload if isinstance(entry, dict)]
+    else:
+        participants = []
+
+    normalized: list[dict[str, Any]] = []
+    for participant in participants:
+        row = {field: (participant.get(field, []) if field == "citizenships" else participant.get(field, "")) for field in _PARTICIPANT_FIELDS}
+        if not isinstance(row.get("citizenships"), list):
+            row["citizenships"] = [str(row.get("citizenships", ""))] if row.get("citizenships") else []
+        normalized.append(row)
+
+    return normalized

--- a/utils/openai_extractor.py
+++ b/utils/openai_extractor.py
@@ -62,7 +62,8 @@ def _resolve_api_key(explicit_key: str | None = None) -> str | None:
         return explicit_key
 
     return (
-        os.getenv("OPENAI_API_KEY")
+        os.getenv("OPENAIAPI")
+        or os.getenv("OPENAI_API_KEY")
         or os.getenv("extractionProjectAPI")
         or os.getenv("EXTRACTION_PROJECT_API")
     )

--- a/utils/openai_extractor.py
+++ b/utils/openai_extractor.py
@@ -4,7 +4,7 @@ import json
 import os
 from typing import Any
 
-MODEL = os.getenv("OPENAI_EXTRACTION_MODEL", "gpt-4.1")
+MODEL = os.getenv("OPENAI_EXTRACTION_MODEL", "gpt-realtime-mini")
 MAX_LENGTH = 12000
 
 _PARTICIPANT_FIELDS = [

--- a/utils/openai_extractor.py
+++ b/utils/openai_extractor.py
@@ -5,7 +5,11 @@ import os
 import traceback
 from typing import Any
 
-MODEL = os.getenv("OPENAI_EXTRACTION_MODEL", "gpt-realtime-mini")
+from dotenv import load_dotenv
+
+load_dotenv()
+
+MODEL = os.getenv("OPENAI_EXTRACTION_MODEL", "gpt-5-mini")
 MAX_LENGTH = 12000
 
 _PARTICIPANT_FIELDS = [


### PR DESCRIPTION
### Motivation
- Provide a workflow to bulk upload DOCX registration forms, extract participant data using an LLM-backed extractor or legacy parser, review and reconcile against existing DB records, and save/link participants to an event.
- Improve import UX by adding a dedicated Docx import page and integrating it into the main navigation.

### Description
- Added a new blueprint `routes/docx_upload.py` exposing `GET /upload/docx`, `POST /upload/docx` (extract), `POST /upload/docx/compare`, and `POST /upload/docx/commit` endpoints with file saving, review, compare, and commit flows using `DocxImportService`.
- Implemented `services/docx_import_service.py` to parse files (LLM first, fallback to legacy), normalize fields, fuzzy-compare against the DB, and create/update participants while linking them to events via repositories.
- Introduced two extraction utilities: `utils/docx_parser.py` for table/paragraph/list pattern parsing and date/gender normalization, and `utils/openai_extractor.py` which builds prompts, calls the OpenAI Responses API, extracts JSON payloads, and normalizes results (with `_resolve_api_key`).
- Added templates `docx_upload.html` and `docx_review.html` for the upload and two-stage review/compare UI, and updated `templates/base.html` to add an Import dropdown that includes the new Docx entry.
- Updated `requirements.txt` to include `python-docx` and `openai`, and added unit tests `tests/test_docx_parser.py`, `tests/test_openai_extractor.py`, `tests/test_docx_import_service_fields.py`, and `tests/test_docx_review_template.py` covering parsing, OpenAI payload handling, payload->model conversion, and template rendering.

### Testing
- Ran the new unit tests with `pytest` focusing on `utils.docx_parser`, `utils.openai_extractor`, `services.docx_import_service` field conversion, and the `docx_review.html` rendering, and all tests passed.
- Verified that template rendering test exercises the compare form fields and the match badge and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84235233483229018ebd87929f74c)